### PR TITLE
Avoid generating type identifiers starting with numbers

### DIFF
--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -229,6 +229,8 @@ export default class ApiGenerator {
   }
 
   getUniqueAlias(name: string) {
+    if (name[0] >= "0" && name[0] <= "9") name = "R" + name;
+
     let used = this.typeAliases[name] || 0;
     if (used) {
       this.typeAliases[name] = ++used;


### PR DESCRIPTION
Not sure if this is the right method to change, and there are probably still other cases where invalid identifiers are generated, but this resolves the specific case of refs with numbers.

Somewhat addresses #34 though the code is still weird