### PR TITLE
feat: query string parameter content support

### DIFF
--- a/demo/contentParams.json
+++ b/demo/contentParams.json
@@ -1,0 +1,56 @@
+{
+  "info": {
+    "title": "example with parameters specified with content",
+    "version": "0.0.1"
+  },
+  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/file": {
+      "get": {
+        "operationId": "QueryFiles",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get the content of a file.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "where": {
+                      "properties": {
+                        "fileId": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/codegen/generate.test.ts
+++ b/src/codegen/generate.test.ts
@@ -57,3 +57,24 @@ describe("generate with blob download", () => {
     );
   });
 });
+
+describe("generate with parameters specified with content", () => {
+  let spec: OpenAPIV3.Document;
+
+  beforeAll(async () => {
+    spec = (await SwaggerParser.bundle(
+      __dirname + "/../../demo/contentParams.json"
+    )) as any;
+  });
+
+  it("should generate an api", async () => {
+    const artefact = printAst(new ApiGenerator(spec).generateApi());
+    const oneLine = artefact.replace(/\s+/g, " ");
+    expect(oneLine).toContain(
+      "export function queryFiles({ filter }: { filter?: { where?: { fileId?: number; }; }; } = {}, opts?: Oazapfts.RequestOpts)"
+    );
+    expect(oneLine).toContain(
+      "return oazapfts.fetchBlob<{ status: 200; data: Blob; }>(`/file${QS.query(QS.json({ filter }))}`, { ...opts });"
+    );
+  });
+});

--- a/src/runtime/query.ts
+++ b/src/runtime/query.ts
@@ -61,6 +61,20 @@ export function explode(
     .join("&");
 }
 
+export function json(
+  params: Record<string, any>,
+  encoders = encodeReserved
+): string {
+  const q = encode(encoders);
+  return Object.entries(params)
+    .filter(([, value]) => value !== undefined)
+    .map(([name, value]) => {
+      const v = JSON.stringify(value);
+      return q`${name}=${v}`;
+    })
+    .join("&");
+}
+
 export const form = delimited();
 export const pipe = delimited("|");
 export const space = delimited("%20");


### PR DESCRIPTION
We use LoopBack (https://loopback.io/), which generates APIs that have complex query string parameters which must be serialized as JSON before adding them to the URL. These are specified in OpenAPI as query string parameters with a `content` property, similar to the following:

```json
{
  "in": "query",
  "name": "filter",
  "content": {
    "application/json": {
      "schema": {
        "properties": {
          "where": {
            "properties": {
              "fileId": {
                "type": "integer"
              }
            },
            "type": "object"
          }
        },
        "type": "object"
      }
    }
  }
}
```

Currently the code generated tries to encode these as form parameters, which fails.

These changes update the code generator to handle these parameters correctly, and serialize them as JSON.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>