### PR TITLE
cleanup duplicated code in keywordType, etc.

### DIFF
--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -1,41 +1,41 @@
-import _ from "lodash";
-import ts, { factory } from "typescript";
-import path from "path";
-import { OpenAPIV3 } from "openapi-types";
-import * as cg from "./tscodegen";
-import generateServers, { defaultBaseUrl } from "./generateServers";
-import { Opts } from ".";
-import { threadId } from "worker_threads";
+import _ from 'lodash';
+import ts, { factory } from 'typescript';
+import path from 'path';
+import { OpenAPIV3 } from 'openapi-types';
+import * as cg from './tscodegen';
+import generateServers, { defaultBaseUrl } from './generateServers';
+import { Opts } from '.';
+import { threadId } from 'worker_threads';
 
 export const verbs = [
-  "GET",
-  "PUT",
-  "POST",
-  "DELETE",
-  "OPTIONS",
-  "HEAD",
-  "PATCH",
-  "TRACE",
+  'GET',
+  'PUT',
+  'POST',
+  'DELETE',
+  'OPTIONS',
+  'HEAD',
+  'PATCH',
+  'TRACE',
 ];
 
-type ContentType = "json" | "form" | "multipart";
+type ContentType = 'json' | 'form' | 'multipart';
 
 export const contentTypes: Record<string, ContentType> = {
-  "*/*": "json",
-  "application/json": "json",
-  "application/hal+json": "json",
-  "application/x-www-form-urlencoded": "form",
-  "multipart/form-data": "multipart",
+  '*/*': 'json',
+  'application/json': 'json',
+  'application/hal+json': 'json',
+  'application/x-www-form-urlencoded': 'form',
+  'multipart/form-data': 'multipart',
 };
 
 /**
  * Get the name of a formatter function for a given parameter.
  */
 export function getFormatter({ style, explode }: OpenAPIV3.ParameterObject) {
-  if (style === "spaceDelimited") return "space";
-  if (style === "pipeDelimited") return "pipe";
-  if (style === "deepObject") return "deep";
-  return explode ? "explode" : "form";
+  if (style === 'spaceDelimited') return 'space';
+  if (style === 'pipeDelimited') return 'pipe';
+  if (style === 'deepObject') return 'deep';
+  return explode ? 'explode' : 'form';
 }
 
 export function getOperationIdentifier(id?: string) {
@@ -52,11 +52,11 @@ export function getOperationIdentifier(id?: string) {
 export function getOperationName(
   verb: string,
   path: string,
-  operationId?: string
+  operationId?: string,
 ) {
   const id = getOperationIdentifier(operationId);
   if (id) return id;
-  path = path.replace(/\{(.+?)\}/, "by $1").replace(/\{(.+?)\}/, "and $1");
+  path = path.replace(/\{(.+?)\}/, 'by $1').replace(/\{(.+?)\}/, 'and $1');
   return _.camelCase(`${verb} ${path}`);
 }
 
@@ -65,18 +65,18 @@ export function isNullable(schema: any) {
 }
 
 export function isReference(obj: any): obj is OpenAPIV3.ReferenceObject {
-  return obj && "$ref" in obj;
+  return obj && '$ref' in obj;
 }
 
 //See https://swagger.io/docs/specification/using-ref/
 export function getReference(spec: OpenAPIV3.Document, ref: string) {
   const path = ref
     .slice(2)
-    .split("/")
-    .map((s) => unescape(s.replace(/~1/g, "/").replace(/~0/g, "~")));
+    .split('/')
+    .map((s) => unescape(s.replace(/~1/g, '/').replace(/~0/g, '~')));
 
   const ret = _.get(spec, path);
-  if (typeof ret === "undefined") {
+  if (typeof ret === 'undefined') {
     throw new Error(`Can't find ${path}`);
   }
   return ret;
@@ -86,7 +86,7 @@ export function getReference(spec: OpenAPIV3.Document, ref: string) {
  */
 export function getReferenceName(obj: any) {
   if (isReference(obj)) {
-    return _.camelCase(obj.$ref.split("/").slice(-1)[0]);
+    return _.camelCase(obj.$ref.split('/').slice(-1)[0]);
   }
 }
 
@@ -104,11 +104,11 @@ export function createUrlExpression(path: string, qs?: ts.Expression) {
       const expression = _.camelCase(name);
       spans.push({ expression: factory.createIdentifier(expression), literal });
       return head;
-    }
+    },
   );
   if (qs) {
     // add the query string as last span
-    spans.push({ expression: qs, literal: "" });
+    spans.push({ expression: qs, literal: '' });
   }
   return cg.createTemplateString(head, spans);
 }
@@ -119,10 +119,10 @@ export function createUrlExpression(path: string, qs?: ts.Expression) {
 export function callQsFunction(name: string, args: ts.Expression[]) {
   return cg.createCall(
     factory.createPropertyAccessExpression(
-      factory.createIdentifier("QS"),
-      name
+      factory.createIdentifier('QS'),
+      name,
     ),
-    { args }
+    { args },
   );
 }
 
@@ -132,14 +132,14 @@ export function callQsFunction(name: string, args: ts.Expression[]) {
 export function callOazapftsFunction(
   name: string,
   args: ts.Expression[],
-  typeArgs?: ts.TypeNode[]
+  typeArgs?: ts.TypeNode[],
 ) {
   return cg.createCall(
     factory.createPropertyAccessExpression(
-      factory.createIdentifier("oazapfts"),
-      name
+      factory.createIdentifier('oazapfts'),
+      name,
     ),
-    { args, typeArgs }
+    { args, typeArgs },
   );
 }
 
@@ -163,9 +163,9 @@ export function supportDeepObjects(params: OpenAPIV3.ParameterObject[]) {
       obj = merged[name] = {
         name,
         in: p.in,
-        style: "deepObject",
+        style: 'deepObject',
         schema: {
-          type: "object",
+          type: 'object',
           properties: {},
         },
       };
@@ -184,7 +184,7 @@ export default class ApiGenerator {
     public readonly spec: OpenAPIV3.Document,
     public readonly opts: Opts = {},
     /** Indicates if the document was converted from an older version of the OpenAPI specification. */
-    public readonly isConverted = false
+    public readonly isConverted = false,
   ) {}
 
   aliases: ts.TypeAliasDeclaration[] = [];
@@ -204,9 +204,9 @@ export default class ApiGenerator {
   resolve<T>(obj: T | OpenAPIV3.ReferenceObject) {
     if (!isReference(obj)) return obj;
     const ref = obj.$ref;
-    if (!ref.startsWith("#/")) {
+    if (!ref.startsWith('#/')) {
       throw new Error(
-        `External refs are not supported (${ref}). Make sure to call SwaggerParser.bundle() first.`
+        `External refs are not supported (${ref}). Make sure to call SwaggerParser.bundle() first.`,
       );
     }
     return getReference(this.spec, ref) as T;
@@ -239,7 +239,7 @@ export default class ApiGenerator {
   }
 
   getRefBasename(ref: string): string {
-    return ref.replace(/.+\//, "");
+    return ref.replace(/.+\//, '');
   }
 
   /**
@@ -251,7 +251,7 @@ export default class ApiGenerator {
     if (!ref) {
       const schema = this.resolve<OpenAPIV3.SchemaObject>(obj);
       const name = this.getUniqueAlias(
-        _.upperFirst(_.camelCase(schema.title || this.getRefBasename($ref)))
+        _.upperFirst(_.camelCase(schema.title || this.getRefBasename($ref))),
       );
 
       ref = this.refs[$ref] = factory.createTypeReferenceNode(name, undefined);
@@ -262,7 +262,7 @@ export default class ApiGenerator {
           modifiers: [cg.modifier.export],
           name,
           type,
-        })
+        }),
       );
     }
     return ref;
@@ -270,12 +270,12 @@ export default class ApiGenerator {
 
   getUnionType(
     variants: (OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject)[],
-    discriminator?: OpenAPIV3.DiscriminatorObject
+    discriminator?: OpenAPIV3.DiscriminatorObject,
   ): ts.TypeNode {
     if (discriminator) {
       // oneOf + discriminator -> tagged union (polymorphism)
       if (discriminator.propertyName === undefined) {
-        throw new Error("Discriminators require a propertyName");
+        throw new Error('Discriminators require a propertyName');
       }
 
       // By default, the last component of the ref name (i.e., after the last trailing slash) is
@@ -283,8 +283,8 @@ export default class ApiGenerator {
       // discriminator.mapping property.
       const mappedValues = new Set(
         Object.values(discriminator.mapping || {}).map((ref) =>
-          this.getRefBasename(ref)
-        )
+          this.getRefBasename(ref),
+        ),
       );
 
       return factory.createUnionTypeNode(
@@ -294,7 +294,7 @@ export default class ApiGenerator {
               ([discriminatorValue, variantRef]) => [
                 discriminatorValue,
                 { $ref: variantRef },
-              ]
+              ],
             ),
             ...variants
               .filter((variant) => {
@@ -302,7 +302,7 @@ export default class ApiGenerator {
                   // From the Swagger spec: "When using the discriminator, inline schemas will not be
                   // considered."
                   throw new Error(
-                    "Discriminators require references, not inline schemas"
+                    'Discriminators require references, not inline schemas',
                   );
                 }
                 return !mappedValues.has(this.getRefBasename(variant.$ref));
@@ -319,18 +319,18 @@ export default class ApiGenerator {
               cg.createPropertySignature({
                 name: discriminator.propertyName,
                 type: factory.createLiteralTypeNode(
-                  factory.createStringLiteral(discriminatorValue)
+                  factory.createStringLiteral(discriminatorValue),
                 ),
               }),
             ]),
             this.getTypeFromSchema(variant),
-          ])
-        )
+          ]),
+        ),
       );
     } else {
       // oneOf -> untagged union
       return factory.createUnionTypeNode(
-        variants.map((schema) => this.getTypeFromSchema(schema))
+        variants.map((schema) => this.getTypeFromSchema(schema)),
       );
     }
   }
@@ -341,7 +341,7 @@ export default class ApiGenerator {
    * optionally adds a union with null.
    */
   getTypeFromSchema(
-    schema?: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject
+    schema?: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
   ): ts.TypeNode {
     const type = this.getBaseTypeFromSchema(schema);
     return isNullable(schema)
@@ -354,7 +354,7 @@ export default class ApiGenerator {
    * schema and returns the appropriate type.
    */
   getBaseTypeFromSchema(
-    schema?: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject
+    schema?: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
   ): ts.TypeNode {
     if (!schema) return cg.keywordType.any;
     if (isReference(schema)) {
@@ -368,16 +368,16 @@ export default class ApiGenerator {
     if (schema.anyOf) {
       // anyOf -> union
       return factory.createUnionTypeNode(
-        schema.anyOf.map((schema) => this.getTypeFromSchema(schema))
+        schema.anyOf.map((schema) => this.getTypeFromSchema(schema)),
       );
     }
     if (schema.allOf) {
       // allOf -> intersection
       return factory.createIntersectionTypeNode(
-        schema.allOf.map((schema) => this.getTypeFromSchema(schema))
+        schema.allOf.map((schema) => this.getTypeFromSchema(schema)),
       );
     }
-    if ("items" in schema) {
+    if ('items' in schema) {
       // items -> array
       return factory.createArrayTypeNode(this.getTypeFromSchema(schema.items));
     }
@@ -386,19 +386,19 @@ export default class ApiGenerator {
       return this.getTypeFromProperties(
         schema.properties || {},
         schema.required,
-        schema.additionalProperties
+        schema.additionalProperties,
       );
     }
     if (schema.enum) {
       // enum -> union of literal types
       return cg.createEnumTypeNode(schema.enum);
     }
-    if (schema.format == "binary") {
-      return factory.createTypeReferenceNode("Blob", []);
+    if (schema.format == 'binary') {
+      return factory.createTypeReferenceNode('Blob', []);
     }
     if (schema.type) {
       // string, boolean, null, number
-      if (schema.type === "integer") return cg.keywordType.number;
+      if (schema.type === 'integer') return cg.keywordType.number;
       if (schema.type in cg.keywordType) return cg.keywordType[schema.type];
     }
 
@@ -416,7 +416,7 @@ export default class ApiGenerator {
     additionalProperties?:
       | boolean
       | OpenAPIV3.SchemaObject
-      | OpenAPIV3.ReferenceObject
+      | OpenAPIV3.ReferenceObject,
   ): ts.TypeLiteralNode {
     const members: ts.TypeElement[] = Object.keys(props).map((name) => {
       const schema = props[name];
@@ -446,13 +446,13 @@ export default class ApiGenerator {
     return factory.createUnionTypeNode(
       Object.entries(responses).map(([code, res]) => {
         const statusType =
-          code === "default"
+          code === 'default'
             ? cg.keywordType.number
             : factory.createLiteralTypeNode(factory.createNumericLiteral(code));
 
         const props = [
           cg.createPropertySignature({
-            name: "status",
+            name: 'status',
             type: statusType,
           }),
         ];
@@ -461,18 +461,18 @@ export default class ApiGenerator {
         if (dataType !== cg.keywordType.void) {
           props.push(
             cg.createPropertySignature({
-              name: "data",
+              name: 'data',
               type: dataType,
-            })
+            }),
           );
         }
         return factory.createTypeLiteralNode(props);
-      })
+      }),
     );
   }
 
   getTypeFromResponse(
-    resOrRef: OpenAPIV3.ResponseObject | OpenAPIV3.ReferenceObject
+    resOrRef: OpenAPIV3.ResponseObject | OpenAPIV3.ReferenceObject,
   ): ts.TypeNode {
     const res = this.resolve(resOrRef);
     if (!res || !res.content) return cg.keywordType.void;
@@ -480,47 +480,47 @@ export default class ApiGenerator {
   }
 
   getResponseType(
-    responses?: OpenAPIV3.ResponsesObject
-  ): "json" | "text" | "blob" {
+    responses?: OpenAPIV3.ResponsesObject,
+  ): 'json' | 'text' | 'blob' {
     // backwards-compatibility
-    if (!responses) return "text";
+    if (!responses) return 'text';
 
     const resolvedResponses = Object.values(responses).map((response) =>
-      this.resolve(response)
+      this.resolve(response),
     );
 
     // if no content is specified, assume `text` (backwards-compatibility)
     if (
       !resolvedResponses.some(
-        (res) => Object.keys(res.content ?? []).length > 0
+        (res) => Object.keys(res.content ?? []).length > 0,
       )
     ) {
-      return "text";
+      return 'text';
     }
 
     const isJson = resolvedResponses.some((response) => {
       const responseMimeTypes = Object.keys(response.content ?? {});
       return responseMimeTypes.some(
-        (mimeType) => contentTypes[mimeType] === "json"
+        (mimeType) => contentTypes[mimeType] === 'json',
       );
     });
 
     // if there’s `application/json` or `*/*`, assume `json`
     if (isJson) {
-      return "json";
+      return 'json';
     }
 
     // if there’s `text/*`, assume `text`
     if (
       resolvedResponses.some((res) =>
-        Object.keys(res.content ?? []).some((type) => type.startsWith("text/"))
+        Object.keys(res.content ?? []).some((type) => type.startsWith('text/')),
       )
     ) {
-      return "text";
+      return 'text';
     }
 
     // for the rest, assume `blob`
-    return "blob";
+    return 'blob';
   }
 
   getSchemaFromContent(content: {
@@ -529,7 +529,7 @@ export default class ApiGenerator {
     const contentType = Object.keys(contentTypes).find((t) => t in content);
     let schema;
     if (contentType) {
-      schema = _.get(content, [contentType, "schema"]);
+      schema = _.get(content, [contentType, 'schema']);
     }
     if (schema) {
       return schema;
@@ -539,17 +539,17 @@ export default class ApiGenerator {
     // `text/*` -> string
     if (
       Object.keys(content).length === 0 ||
-      Object.keys(content).some((type) => type.startsWith("text/"))
+      Object.keys(content).some((type) => type.startsWith('text/'))
     ) {
-      return { type: "string" };
+      return { type: 'string' };
     }
 
     // rest (e.g. `application/octet-stream`, `application/gzip`, …) -> binary
-    return { type: "string", format: "binary" };
+    return { type: 'string', format: 'binary' };
   }
 
   wrapResult(ex: ts.Expression) {
-    return this.opts?.optimistic ? callOazapftsFunction("ok", [ex]) : ex;
+    return this.opts?.optimistic ? callOazapftsFunction('ok', [ex]) : ex;
   }
 
   generateApi(): ts.SourceFile {
@@ -557,11 +557,11 @@ export default class ApiGenerator {
 
     // Parse ApiStub.ts so that we don't have to generate everything manually
     const stub = cg.parseFile(
-      path.resolve(__dirname, "../../src/codegen/ApiStub.ts")
+      path.resolve(__dirname, '../../src/codegen/ApiStub.ts'),
     );
 
     // ApiStub contains `const servers = {}`, find it ...
-    const servers = cg.findFirstVariableDeclaration(stub.statements, "servers");
+    const servers = cg.findFirstVariableDeclaration(stub.statements, 'servers');
     // servers.initializer is readonly, this might break in a future TS version, but works fine for now.
     Object.assign(servers, {
       initializer: generateServers(this.spec.servers || []),
@@ -569,16 +569,16 @@ export default class ApiGenerator {
 
     const { initializer } = cg.findFirstVariableDeclaration(
       stub.statements,
-      "defaults"
+      'defaults',
     );
     if (!initializer || !ts.isObjectLiteralExpression(initializer)) {
-      throw new Error("No object literal: defaults");
+      throw new Error('No object literal: defaults');
     }
 
     cg.changePropertyValue(
       initializer,
-      "baseUrl",
-      defaultBaseUrl(this.spec.servers || [])
+      'baseUrl',
+      defaultBaseUrl(this.spec.servers || []),
     );
 
     // Collect class functions to be added...
@@ -634,7 +634,7 @@ export default class ApiGenerator {
           : resolvedParameters;
 
         // split into required/optional
-        const [required, optional] = _.partition(parameters, "required");
+        const [required, optional] = _.partition(parameters, 'required');
 
         // convert parameter names to argument names ...
         const argNames: Record<string, string> = {};
@@ -649,7 +649,7 @@ export default class ApiGenerator {
         const methodParams = required.map((p) =>
           cg.createParameter(argNames[this.resolve(p).name], {
             type: this.getTypeFromSchema(isReference(p) ? p : p.schema),
-          })
+          }),
         );
 
         let body: OpenAPIV3.RequestBodyObject | undefined;
@@ -661,13 +661,13 @@ export default class ApiGenerator {
           const schema = this.getSchemaFromContent(body.content);
           const type = this.getTypeFromSchema(schema);
           bodyVar = _.camelCase(
-            (type as any).name || getReferenceName(schema) || "body"
+            (type as any).name || getReferenceName(schema) || 'body',
           );
           methodParams.push(
             cg.createParameter(bodyVar, {
               type,
               questionToken: !body.required,
-            })
+            }),
           );
         }
 
@@ -678,7 +678,7 @@ export default class ApiGenerator {
               cg.createObjectBinding(
                 optional
                   .map((param) => this.resolve(param))
-                  .map(({ name }) => ({ name: argNames[name] }))
+                  .map(({ name }) => ({ name: argNames[name] })),
               ),
               {
                 initializer: factory.createObjectLiteralExpression(),
@@ -688,97 +688,97 @@ export default class ApiGenerator {
                       name: argNames[this.resolve(p).name],
                       questionToken: true,
                       type: this.getTypeFromSchema(
-                        isReference(p) ? p : p.schema
+                        isReference(p) ? p : p.schema,
                       ),
-                    })
-                  )
+                    }),
+                  ),
                 ),
-              }
-            )
+              },
+            ),
           );
         }
 
         methodParams.push(
-          cg.createParameter("opts", {
+          cg.createParameter('opts', {
             type: factory.createTypeReferenceNode(
-              "Oazapfts.RequestOpts",
-              undefined
+              'Oazapfts.RequestOpts',
+              undefined,
             ),
             questionToken: true,
-          })
+          }),
         );
 
         // Next, build the method body...
 
         const returnType = this.getResponseType(responses);
-        const query = parameters.filter((p) => p.in === "query");
+        const query = parameters.filter((p) => p.in === 'query');
         const header = parameters
-          .filter((p) => p.in === "header")
+          .filter((p) => p.in === 'header')
           .map((p) => p.name);
         let qs;
         if (query.length) {
           const paramsByFormatter = _.groupBy(query, getFormatter);
           qs = callQsFunction(
-            "query",
+            'query',
             Object.entries(paramsByFormatter).map(([format, params]) => {
               //const [allowReserved, encodeReserved] = _.partition(params, "allowReserved");
               return callQsFunction(format, [
                 cg.createObjectLiteral(
-                  params.map((p) => [p.name, argNames[p.name]])
+                  params.map((p) => [p.name, argNames[p.name]]),
                 ),
               ]);
-            })
+            }),
           );
         }
 
         const url = createUrlExpression(path, qs);
         const init: ts.ObjectLiteralElementLike[] = [
-          factory.createSpreadAssignment(factory.createIdentifier("opts")),
+          factory.createSpreadAssignment(factory.createIdentifier('opts')),
         ];
 
-        if (method !== "GET") {
+        if (method !== 'GET') {
           init.push(
             factory.createPropertyAssignment(
-              "method",
-              factory.createStringLiteral(method)
-            )
+              'method',
+              factory.createStringLiteral(method),
+            ),
           );
         }
 
         if (bodyVar) {
           init.push(
             cg.createPropertyAssignment(
-              "body",
-              factory.createIdentifier(bodyVar)
-            )
+              'body',
+              factory.createIdentifier(bodyVar),
+            ),
           );
         }
 
         if (header.length) {
           init.push(
             factory.createPropertyAssignment(
-              "headers",
+              'headers',
               factory.createObjectLiteralExpression(
                 [
                   factory.createSpreadAssignment(
                     factory.createLogicalAnd(
-                      factory.createIdentifier("opts"),
+                      factory.createIdentifier('opts'),
                       factory.createPropertyAccessExpression(
-                        factory.createIdentifier("opts"),
-                        "headers"
-                      )
-                    )
+                        factory.createIdentifier('opts'),
+                        'headers',
+                      ),
+                    ),
                   ),
                   ...header.map((name) =>
                     cg.createPropertyAssignment(
                       name,
-                      factory.createIdentifier(argNames[name])
-                    )
+                      factory.createIdentifier(argNames[name]),
+                    ),
                   ),
                 ],
-                true
-              )
-            )
+                true,
+              ),
+            ),
           );
         }
 
@@ -786,7 +786,7 @@ export default class ApiGenerator {
 
         if (init.length) {
           const m = Object.entries(contentTypes).find(([type]) => {
-            return !!_.get(body, ["content", type]);
+            return !!_.get(body, ['content', type]);
           });
           const initObj = factory.createObjectLiteralExpression(init, true);
           args.push(m ? callOazapftsFunction(m[1], [initObj]) : initObj); // json, form, multipart
@@ -805,24 +805,24 @@ export default class ApiGenerator {
                   this.wrapResult(
                     callOazapftsFunction(
                       {
-                        json: "fetchJson",
-                        text: "fetchText",
-                        blob: "fetchBlob",
+                        json: 'fetchJson',
+                        text: 'fetchText',
+                        blob: 'fetchBlob',
                       }[returnType],
                       args,
-                      returnType === "json" || returnType === "blob"
+                      returnType === 'json' || returnType === 'blob'
                         ? [
                             this.getTypeFromResponses(responses!) ||
                               ts.SyntaxKind.AnyKeyword,
                           ]
-                        : undefined
-                    )
-                  )
-                )
-              )
+                        : undefined,
+                    ),
+                  ),
+                ),
+              ),
             ),
-            summary || description
-          )
+            summary || description,
+          ),
         );
       });
     });
@@ -830,7 +830,7 @@ export default class ApiGenerator {
     Object.assign(stub, {
       statements: cg.appendNodes(
         stub.statements,
-        ...[...this.aliases, ...functions]
+        ...[...this.aliases, ...functions],
       ),
     });
 

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -1,41 +1,41 @@
-import _ from 'lodash';
-import ts, { factory } from 'typescript';
-import path from 'path';
-import { OpenAPIV3 } from 'openapi-types';
-import * as cg from './tscodegen';
-import generateServers, { defaultBaseUrl } from './generateServers';
-import { Opts } from '.';
-import { threadId } from 'worker_threads';
+import _ from "lodash";
+import ts, { factory } from "typescript";
+import path from "path";
+import { OpenAPIV3 } from "openapi-types";
+import * as cg from "./tscodegen";
+import generateServers, { defaultBaseUrl } from "./generateServers";
+import { Opts } from ".";
+import { threadId } from "worker_threads";
 
 export const verbs = [
-  'GET',
-  'PUT',
-  'POST',
-  'DELETE',
-  'OPTIONS',
-  'HEAD',
-  'PATCH',
-  'TRACE',
+  "GET",
+  "PUT",
+  "POST",
+  "DELETE",
+  "OPTIONS",
+  "HEAD",
+  "PATCH",
+  "TRACE",
 ];
 
-type ContentType = 'json' | 'form' | 'multipart';
+type ContentType = "json" | "form" | "multipart";
 
 export const contentTypes: Record<string, ContentType> = {
-  '*/*': 'json',
-  'application/json': 'json',
-  'application/hal+json': 'json',
-  'application/x-www-form-urlencoded': 'form',
-  'multipart/form-data': 'multipart',
+  "*/*": "json",
+  "application/json": "json",
+  "application/hal+json": "json",
+  "application/x-www-form-urlencoded": "form",
+  "multipart/form-data": "multipart",
 };
 
 /**
  * Get the name of a formatter function for a given parameter.
  */
 export function getFormatter({ style, explode }: OpenAPIV3.ParameterObject) {
-  if (style === 'spaceDelimited') return 'space';
-  if (style === 'pipeDelimited') return 'pipe';
-  if (style === 'deepObject') return 'deep';
-  return explode ? 'explode' : 'form';
+  if (style === "spaceDelimited") return "space";
+  if (style === "pipeDelimited") return "pipe";
+  if (style === "deepObject") return "deep";
+  return explode ? "explode" : "form";
 }
 
 export function getOperationIdentifier(id?: string) {
@@ -52,11 +52,11 @@ export function getOperationIdentifier(id?: string) {
 export function getOperationName(
   verb: string,
   path: string,
-  operationId?: string,
+  operationId?: string
 ) {
   const id = getOperationIdentifier(operationId);
   if (id) return id;
-  path = path.replace(/\{(.+?)\}/, 'by $1').replace(/\{(.+?)\}/, 'and $1');
+  path = path.replace(/\{(.+?)\}/, "by $1").replace(/\{(.+?)\}/, "and $1");
   return _.camelCase(`${verb} ${path}`);
 }
 
@@ -65,18 +65,18 @@ export function isNullable(schema: any) {
 }
 
 export function isReference(obj: any): obj is OpenAPIV3.ReferenceObject {
-  return obj && '$ref' in obj;
+  return obj && "$ref" in obj;
 }
 
 //See https://swagger.io/docs/specification/using-ref/
-export function getReference(spec: any, ref: string) {
+export function getReference(spec: OpenAPIV3.Document, ref: string) {
   const path = ref
     .slice(2)
-    .split('/')
-    .map((s) => unescape(s.replace(/~1/g, '/').replace(/~0/g, '~')));
+    .split("/")
+    .map((s) => unescape(s.replace(/~1/g, "/").replace(/~0/g, "~")));
 
   const ret = _.get(spec, path);
-  if (typeof ret === 'undefined') {
+  if (typeof ret === "undefined") {
     throw new Error(`Can't find ${path}`);
   }
   return ret;
@@ -86,7 +86,7 @@ export function getReference(spec: any, ref: string) {
  */
 export function getReferenceName(obj: any) {
   if (isReference(obj)) {
-    return _.camelCase(obj.$ref.split('/').slice(-1)[0]);
+    return _.camelCase(obj.$ref.split("/").slice(-1)[0]);
   }
 }
 
@@ -104,11 +104,11 @@ export function createUrlExpression(path: string, qs?: ts.Expression) {
       const expression = _.camelCase(name);
       spans.push({ expression: factory.createIdentifier(expression), literal });
       return head;
-    },
+    }
   );
   if (qs) {
     // add the query string as last span
-    spans.push({ expression: qs, literal: '' });
+    spans.push({ expression: qs, literal: "" });
   }
   return cg.createTemplateString(head, spans);
 }
@@ -119,10 +119,10 @@ export function createUrlExpression(path: string, qs?: ts.Expression) {
 export function callQsFunction(name: string, args: ts.Expression[]) {
   return cg.createCall(
     factory.createPropertyAccessExpression(
-      factory.createIdentifier('QS'),
-      name,
+      factory.createIdentifier("QS"),
+      name
     ),
-    { args },
+    { args }
   );
 }
 
@@ -132,14 +132,14 @@ export function callQsFunction(name: string, args: ts.Expression[]) {
 export function callOazapftsFunction(
   name: string,
   args: ts.Expression[],
-  typeArgs?: ts.TypeNode[],
+  typeArgs?: ts.TypeNode[]
 ) {
   return cg.createCall(
     factory.createPropertyAccessExpression(
-      factory.createIdentifier('oazapfts'),
-      name,
+      factory.createIdentifier("oazapfts"),
+      name
     ),
-    { args, typeArgs },
+    { args, typeArgs }
   );
 }
 
@@ -163,9 +163,9 @@ export function supportDeepObjects(params: OpenAPIV3.ParameterObject[]) {
       obj = merged[name] = {
         name,
         in: p.in,
-        style: 'deepObject',
+        style: "deepObject",
         schema: {
-          type: 'object',
+          type: "object",
           properties: {},
         },
       };
@@ -184,7 +184,7 @@ export default class ApiGenerator {
     public readonly spec: OpenAPIV3.Document,
     public readonly opts: Opts = {},
     /** Indicates if the document was converted from an older version of the OpenAPI specification. */
-    public readonly isConverted = false,
+    public readonly isConverted = false
   ) {}
 
   aliases: ts.TypeAliasDeclaration[] = [];
@@ -204,9 +204,9 @@ export default class ApiGenerator {
   resolve<T>(obj: T | OpenAPIV3.ReferenceObject) {
     if (!isReference(obj)) return obj;
     const ref = obj.$ref;
-    if (!ref.startsWith('#/')) {
+    if (!ref.startsWith("#/")) {
       throw new Error(
-        `External refs are not supported (${ref}). Make sure to call SwaggerParser.bundle() first.`,
+        `External refs are not supported (${ref}). Make sure to call SwaggerParser.bundle() first.`
       );
     }
     return getReference(this.spec, ref) as T;
@@ -216,7 +216,7 @@ export default class ApiGenerator {
     return array ? array.map((el) => this.resolve(el)) : [];
   }
 
-  skip(tags?: string[]) {
+  skip(tags?: string[]): boolean {
     const excluded = tags && tags.some((t) => this.opts?.exclude?.includes(t));
     if (excluded) {
       return true;
@@ -228,7 +228,7 @@ export default class ApiGenerator {
     return false;
   }
 
-  getUniqueAlias(name: string) {
+  getUniqueAlias(name: string): string {
     let used = this.typeAliases[name] || 0;
     if (used) {
       this.typeAliases[name] = ++used;
@@ -239,19 +239,19 @@ export default class ApiGenerator {
   }
 
   getRefBasename(ref: string): string {
-    return ref.replace(/.+\//, '');
+    return ref.replace(/.+\//, "");
   }
 
   /**
    * Create a type alias for the schema referenced by the given ReferenceObject
    */
-  getRefAlias(obj: OpenAPIV3.ReferenceObject) {
+  getRefAlias(obj: OpenAPIV3.ReferenceObject): ts.TypeReferenceNode {
     const { $ref } = obj;
     let ref = this.refs[$ref];
     if (!ref) {
       const schema = this.resolve<OpenAPIV3.SchemaObject>(obj);
       const name = this.getUniqueAlias(
-        _.upperFirst(_.camelCase(schema.title || this.getRefBasename($ref))),
+        _.upperFirst(_.camelCase(schema.title || this.getRefBasename($ref)))
       );
 
       ref = this.refs[$ref] = factory.createTypeReferenceNode(name, undefined);
@@ -262,7 +262,7 @@ export default class ApiGenerator {
           modifiers: [cg.modifier.export],
           name,
           type,
-        }),
+        })
       );
     }
     return ref;
@@ -270,12 +270,12 @@ export default class ApiGenerator {
 
   getUnionType(
     variants: (OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject)[],
-    discriminator?: OpenAPIV3.DiscriminatorObject,
+    discriminator?: OpenAPIV3.DiscriminatorObject
   ): ts.TypeNode {
     if (discriminator) {
       // oneOf + discriminator -> tagged union (polymorphism)
       if (discriminator.propertyName === undefined) {
-        throw new Error('Discriminators require a propertyName');
+        throw new Error("Discriminators require a propertyName");
       }
 
       // By default, the last component of the ref name (i.e., after the last trailing slash) is
@@ -283,8 +283,8 @@ export default class ApiGenerator {
       // discriminator.mapping property.
       const mappedValues = new Set(
         Object.values(discriminator.mapping || {}).map((ref) =>
-          this.getRefBasename(ref),
-        ),
+          this.getRefBasename(ref)
+        )
       );
 
       return factory.createUnionTypeNode(
@@ -294,7 +294,7 @@ export default class ApiGenerator {
               ([discriminatorValue, variantRef]) => [
                 discriminatorValue,
                 { $ref: variantRef },
-              ],
+              ]
             ),
             ...variants
               .filter((variant) => {
@@ -302,7 +302,7 @@ export default class ApiGenerator {
                   // From the Swagger spec: "When using the discriminator, inline schemas will not be
                   // considered."
                   throw new Error(
-                    'Discriminators require references, not inline schemas',
+                    "Discriminators require references, not inline schemas"
                   );
                 }
                 return !mappedValues.has(this.getRefBasename(variant.$ref));
@@ -319,18 +319,18 @@ export default class ApiGenerator {
               cg.createPropertySignature({
                 name: discriminator.propertyName,
                 type: factory.createLiteralTypeNode(
-                  factory.createStringLiteral(discriminatorValue),
+                  factory.createStringLiteral(discriminatorValue)
                 ),
               }),
             ]),
             this.getTypeFromSchema(variant),
-          ]),
-        ),
+          ])
+        )
       );
     } else {
       // oneOf -> untagged union
       return factory.createUnionTypeNode(
-        variants.map((schema) => this.getTypeFromSchema(schema)),
+        variants.map((schema) => this.getTypeFromSchema(schema))
       );
     }
   }
@@ -341,7 +341,7 @@ export default class ApiGenerator {
    * optionally adds a union with null.
    */
   getTypeFromSchema(
-    schema?: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
+    schema?: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject
   ): ts.TypeNode {
     const type = this.getBaseTypeFromSchema(schema);
     return isNullable(schema)
@@ -354,7 +354,7 @@ export default class ApiGenerator {
    * schema and returns the appropriate type.
    */
   getBaseTypeFromSchema(
-    schema?: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
+    schema?: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject
   ): ts.TypeNode {
     if (!schema) return cg.keywordType.any;
     if (isReference(schema)) {
@@ -368,16 +368,16 @@ export default class ApiGenerator {
     if (schema.anyOf) {
       // anyOf -> union
       return factory.createUnionTypeNode(
-        schema.anyOf.map((schema) => this.getTypeFromSchema(schema)),
+        schema.anyOf.map((schema) => this.getTypeFromSchema(schema))
       );
     }
     if (schema.allOf) {
       // allOf -> intersection
       return factory.createIntersectionTypeNode(
-        schema.allOf.map((schema) => this.getTypeFromSchema(schema)),
+        schema.allOf.map((schema) => this.getTypeFromSchema(schema))
       );
     }
-    if ('items' in schema) {
+    if ("items" in schema) {
       // items -> array
       return factory.createArrayTypeNode(this.getTypeFromSchema(schema.items));
     }
@@ -386,34 +386,20 @@ export default class ApiGenerator {
       return this.getTypeFromProperties(
         schema.properties || {},
         schema.required,
-        schema.additionalProperties,
+        schema.additionalProperties
       );
     }
     if (schema.enum) {
       // enum -> union of literal types
-      const types = schema.enum.map((s) => {
-        if (s === null) return cg.keywordType.null;
-        if (typeof s === 'boolean')
-          return s
-            ? factory.createLiteralTypeNode(
-                ts.factory.createToken(ts.SyntaxKind.TrueKeyword),
-              )
-            : factory.createLiteralTypeNode(
-                ts.factory.createToken(ts.SyntaxKind.FalseKeyword),
-              );
-        if (typeof s === 'number')
-          return factory.createLiteralTypeNode(factory.createNumericLiteral(s));
-        return factory.createLiteralTypeNode(factory.createStringLiteral(s));
-      });
-      return types.length > 1 ? factory.createUnionTypeNode(types) : types[0];
+      return cg.createEnumTypeNode(schema.enum);
     }
-    if (schema.format == 'binary') {
-      return factory.createTypeReferenceNode('Blob', []);
+    if (schema.format == "binary") {
+      return factory.createTypeReferenceNode("Blob", []);
     }
     if (schema.type) {
       // string, boolean, null, number
+      if (schema.type === "integer") return cg.keywordType.number;
       if (schema.type in cg.keywordType) return cg.keywordType[schema.type];
-      if (schema.type === 'integer') return cg.keywordType.number;
     }
 
     return cg.keywordType.any;
@@ -430,8 +416,8 @@ export default class ApiGenerator {
     additionalProperties?:
       | boolean
       | OpenAPIV3.SchemaObject
-      | OpenAPIV3.ReferenceObject,
-  ) {
+      | OpenAPIV3.ReferenceObject
+  ): ts.TypeLiteralNode {
     const members: ts.TypeElement[] = Object.keys(props).map((name) => {
       const schema = props[name];
       const isRequired = required && required.includes(name);
@@ -456,17 +442,17 @@ export default class ApiGenerator {
     return factory.createTypeLiteralNode(members);
   }
 
-  getTypeFromResponses(responses: OpenAPIV3.ResponsesObject) {
+  getTypeFromResponses(responses: OpenAPIV3.ResponsesObject): ts.UnionTypeNode {
     return factory.createUnionTypeNode(
       Object.entries(responses).map(([code, res]) => {
         const statusType =
-          code === 'default'
+          code === "default"
             ? cg.keywordType.number
             : factory.createLiteralTypeNode(factory.createNumericLiteral(code));
 
         const props = [
           cg.createPropertySignature({
-            name: 'status',
+            name: "status",
             type: statusType,
           }),
         ];
@@ -475,73 +461,75 @@ export default class ApiGenerator {
         if (dataType !== cg.keywordType.void) {
           props.push(
             cg.createPropertySignature({
-              name: 'data',
+              name: "data",
               type: dataType,
-            }),
+            })
           );
         }
         return factory.createTypeLiteralNode(props);
-      }),
+      })
     );
   }
 
   getTypeFromResponse(
-    resOrRef: OpenAPIV3.ResponseObject | OpenAPIV3.ReferenceObject,
-  ) {
+    resOrRef: OpenAPIV3.ResponseObject | OpenAPIV3.ReferenceObject
+  ): ts.TypeNode {
     const res = this.resolve(resOrRef);
     if (!res || !res.content) return cg.keywordType.void;
     return this.getTypeFromSchema(this.getSchemaFromContent(res.content));
   }
 
   getResponseType(
-    responses?: OpenAPIV3.ResponsesObject,
-  ): 'json' | 'text' | 'blob' {
+    responses?: OpenAPIV3.ResponsesObject
+  ): "json" | "text" | "blob" {
     // backwards-compatibility
-    if (!responses) return 'text';
+    if (!responses) return "text";
 
     const resolvedResponses = Object.values(responses).map((response) =>
-      this.resolve(response),
+      this.resolve(response)
     );
 
     // if no content is specified, assume `text` (backwards-compatibility)
     if (
       !resolvedResponses.some(
-        (res) => Object.keys(res.content ?? []).length > 0,
+        (res) => Object.keys(res.content ?? []).length > 0
       )
     ) {
-      return 'text';
+      return "text";
     }
 
     const isJson = resolvedResponses.some((response) => {
       const responseMimeTypes = Object.keys(response.content ?? {});
       return responseMimeTypes.some(
-        (mimeType) => contentTypes[mimeType] === 'json',
+        (mimeType) => contentTypes[mimeType] === "json"
       );
     });
 
     // if there’s `application/json` or `*/*`, assume `json`
     if (isJson) {
-      return 'json';
+      return "json";
     }
 
     // if there’s `text/*`, assume `text`
     if (
       resolvedResponses.some((res) =>
-        Object.keys(res.content ?? []).some((type) => type.startsWith('text/')),
+        Object.keys(res.content ?? []).some((type) => type.startsWith("text/"))
       )
     ) {
-      return 'text';
+      return "text";
     }
 
     // for the rest, assume `blob`
-    return 'blob';
+    return "blob";
   }
 
-  getSchemaFromContent(content: any) {
+  getSchemaFromContent(content: {
+    [media: string]: OpenAPIV3.MediaTypeObject;
+  }): OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject {
     const contentType = Object.keys(contentTypes).find((t) => t in content);
     let schema;
     if (contentType) {
-      schema = _.get(content, [contentType, 'schema']);
+      schema = _.get(content, [contentType, "schema"]);
     }
     if (schema) {
       return schema;
@@ -551,29 +539,29 @@ export default class ApiGenerator {
     // `text/*` -> string
     if (
       Object.keys(content).length === 0 ||
-      Object.keys(content).some((type) => type.startsWith('text/'))
+      Object.keys(content).some((type) => type.startsWith("text/"))
     ) {
-      return { type: 'string' };
+      return { type: "string" };
     }
 
     // rest (e.g. `application/octet-stream`, `application/gzip`, …) -> binary
-    return { type: 'string', format: 'binary' };
+    return { type: "string", format: "binary" };
   }
 
   wrapResult(ex: ts.Expression) {
-    return this.opts?.optimistic ? callOazapftsFunction('ok', [ex]) : ex;
+    return this.opts?.optimistic ? callOazapftsFunction("ok", [ex]) : ex;
   }
 
-  generateApi() {
+  generateApi(): ts.SourceFile {
     this.reset();
 
     // Parse ApiStub.ts so that we don't have to generate everything manually
     const stub = cg.parseFile(
-      path.resolve(__dirname, '../../src/codegen/ApiStub.ts'),
+      path.resolve(__dirname, "../../src/codegen/ApiStub.ts")
     );
 
     // ApiStub contains `const servers = {}`, find it ...
-    const servers = cg.findFirstVariableDeclaration(stub.statements, 'servers');
+    const servers = cg.findFirstVariableDeclaration(stub.statements, "servers");
     // servers.initializer is readonly, this might break in a future TS version, but works fine for now.
     Object.assign(servers, {
       initializer: generateServers(this.spec.servers || []),
@@ -581,16 +569,16 @@ export default class ApiGenerator {
 
     const { initializer } = cg.findFirstVariableDeclaration(
       stub.statements,
-      'defaults',
+      "defaults"
     );
     if (!initializer || !ts.isObjectLiteralExpression(initializer)) {
-      throw new Error('No object literal: defaults');
+      throw new Error("No object literal: defaults");
     }
 
     cg.changePropertyValue(
       initializer,
-      'baseUrl',
-      defaultBaseUrl(this.spec.servers || []),
+      "baseUrl",
+      defaultBaseUrl(this.spec.servers || [])
     );
 
     // Collect class functions to be added...
@@ -646,10 +634,10 @@ export default class ApiGenerator {
           : resolvedParameters;
 
         // split into required/optional
-        const [required, optional] = _.partition(parameters, 'required');
+        const [required, optional] = _.partition(parameters, "required");
 
         // convert parameter names to argument names ...
-        const argNames: any = {};
+        const argNames: Record<string, string> = {};
         parameters
           .map((p) => p.name)
           .sort((a, b) => a.length - b.length)
@@ -661,10 +649,10 @@ export default class ApiGenerator {
         const methodParams = required.map((p) =>
           cg.createParameter(argNames[this.resolve(p).name], {
             type: this.getTypeFromSchema(isReference(p) ? p : p.schema),
-          }),
+          })
         );
 
-        let body: any;
+        let body: OpenAPIV3.RequestBodyObject | undefined;
         let bodyVar;
 
         // add body if present
@@ -673,13 +661,13 @@ export default class ApiGenerator {
           const schema = this.getSchemaFromContent(body.content);
           const type = this.getTypeFromSchema(schema);
           bodyVar = _.camelCase(
-            (type as any).name || getReferenceName(schema) || 'body',
+            (type as any).name || getReferenceName(schema) || "body"
           );
           methodParams.push(
             cg.createParameter(bodyVar, {
               type,
               questionToken: !body.required,
-            }),
+            })
           );
         }
 
@@ -690,7 +678,7 @@ export default class ApiGenerator {
               cg.createObjectBinding(
                 optional
                   .map((param) => this.resolve(param))
-                  .map(({ name }) => ({ name: argNames[name] })),
+                  .map(({ name }) => ({ name: argNames[name] }))
               ),
               {
                 initializer: factory.createObjectLiteralExpression(),
@@ -700,97 +688,97 @@ export default class ApiGenerator {
                       name: argNames[this.resolve(p).name],
                       questionToken: true,
                       type: this.getTypeFromSchema(
-                        isReference(p) ? p : p.schema,
+                        isReference(p) ? p : p.schema
                       ),
-                    }),
-                  ),
+                    })
+                  )
                 ),
-              },
-            ),
+              }
+            )
           );
         }
 
         methodParams.push(
-          cg.createParameter('opts', {
+          cg.createParameter("opts", {
             type: factory.createTypeReferenceNode(
-              'Oazapfts.RequestOpts',
-              undefined,
+              "Oazapfts.RequestOpts",
+              undefined
             ),
             questionToken: true,
-          }),
+          })
         );
 
         // Next, build the method body...
 
         const returnType = this.getResponseType(responses);
-        const query = parameters.filter((p) => p.in === 'query');
+        const query = parameters.filter((p) => p.in === "query");
         const header = parameters
-          .filter((p) => p.in === 'header')
+          .filter((p) => p.in === "header")
           .map((p) => p.name);
         let qs;
         if (query.length) {
           const paramsByFormatter = _.groupBy(query, getFormatter);
           qs = callQsFunction(
-            'query',
+            "query",
             Object.entries(paramsByFormatter).map(([format, params]) => {
               //const [allowReserved, encodeReserved] = _.partition(params, "allowReserved");
               return callQsFunction(format, [
                 cg.createObjectLiteral(
-                  params.map((p) => [p.name, argNames[p.name]]),
+                  params.map((p) => [p.name, argNames[p.name]])
                 ),
               ]);
-            }),
+            })
           );
         }
 
         const url = createUrlExpression(path, qs);
         const init: ts.ObjectLiteralElementLike[] = [
-          factory.createSpreadAssignment(factory.createIdentifier('opts')),
+          factory.createSpreadAssignment(factory.createIdentifier("opts")),
         ];
 
-        if (method !== 'GET') {
+        if (method !== "GET") {
           init.push(
             factory.createPropertyAssignment(
-              'method',
-              factory.createStringLiteral(method),
-            ),
+              "method",
+              factory.createStringLiteral(method)
+            )
           );
         }
 
         if (bodyVar) {
           init.push(
             cg.createPropertyAssignment(
-              'body',
-              factory.createIdentifier(bodyVar),
-            ),
+              "body",
+              factory.createIdentifier(bodyVar)
+            )
           );
         }
 
         if (header.length) {
           init.push(
             factory.createPropertyAssignment(
-              'headers',
+              "headers",
               factory.createObjectLiteralExpression(
                 [
                   factory.createSpreadAssignment(
                     factory.createLogicalAnd(
-                      factory.createIdentifier('opts'),
+                      factory.createIdentifier("opts"),
                       factory.createPropertyAccessExpression(
-                        factory.createIdentifier('opts'),
-                        'headers',
-                      ),
-                    ),
+                        factory.createIdentifier("opts"),
+                        "headers"
+                      )
+                    )
                   ),
                   ...header.map((name) =>
                     cg.createPropertyAssignment(
                       name,
-                      factory.createIdentifier(argNames[name]),
-                    ),
+                      factory.createIdentifier(argNames[name])
+                    )
                   ),
                 ],
-                true,
-              ),
-            ),
+                true
+              )
+            )
           );
         }
 
@@ -798,7 +786,7 @@ export default class ApiGenerator {
 
         if (init.length) {
           const m = Object.entries(contentTypes).find(([type]) => {
-            return !!_.get(body, ['content', type]);
+            return !!_.get(body, ["content", type]);
           });
           const initObj = factory.createObjectLiteralExpression(init, true);
           args.push(m ? callOazapftsFunction(m[1], [initObj]) : initObj); // json, form, multipart
@@ -817,24 +805,24 @@ export default class ApiGenerator {
                   this.wrapResult(
                     callOazapftsFunction(
                       {
-                        json: 'fetchJson',
-                        text: 'fetchText',
-                        blob: 'fetchBlob',
+                        json: "fetchJson",
+                        text: "fetchText",
+                        blob: "fetchBlob",
                       }[returnType],
                       args,
-                      returnType === 'json' || returnType === 'blob'
+                      returnType === "json" || returnType === "blob"
                         ? [
                             this.getTypeFromResponses(responses!) ||
                               ts.SyntaxKind.AnyKeyword,
                           ]
-                        : undefined,
-                    ),
-                  ),
-                ),
-              ),
+                        : undefined
+                    )
+                  )
+                )
+              )
             ),
-            summary || description,
-          ),
+            summary || description
+          )
         );
       });
     });
@@ -842,7 +830,7 @@ export default class ApiGenerator {
     Object.assign(stub, {
       statements: cg.appendNodes(
         stub.statements,
-        ...[...this.aliases, ...functions],
+        ...[...this.aliases, ...functions]
       ),
     });
 

--- a/src/codegen/generateServers.ts
+++ b/src/codegen/generateServers.ts
@@ -1,40 +1,17 @@
 import _ from "lodash";
 import * as cg from "./tscodegen";
-import ts, { TypeNode, TemplateLiteral, factory } from "typescript";
+import ts, { factory } from "typescript";
 import { OpenAPIV3 } from "openapi-types";
 
-function createLiteral(v: string | boolean | number) {
-  switch (typeof v) {
-    case "string":
-      return factory.createStringLiteral(v);
-    case "boolean":
-      return v ? factory.createTrue() : factory.createFalse();
-    case "number":
-      return factory.createNumericLiteral(String(v));
-  }
-}
-
-function createUnion(strs: (string | boolean | number)[]): TypeNode[] {
-  return strs.map((e): TypeNode => {
-    return factory.createLiteralTypeNode(createLiteral(e));
-  });
-}
-
-function createTemplate(url: string): TemplateLiteral {
+function createTemplate(url: string) {
   const tokens = url.split(/{([\s\S]+?)}/g);
   const chunks = _.chunk(tokens.slice(1), 2);
-  return factory.createTemplateExpression(
-    factory.createTemplateHead(tokens[0]),
-    [
-      ...chunks.map(([expression, literal], i) => {
-        return factory.createTemplateSpan(
-          factory.createIdentifier(expression),
-          (i === chunks.length - 1
-            ? factory.createTemplateTail
-            : factory.createTemplateMiddle)(literal)
-        );
-      }),
-    ]
+  return cg.createTemplateString(
+    tokens[0],
+    chunks.map(([expression, literal]) => ({
+      expression: factory.createIdentifier(expression),
+      literal,
+    }))
   );
 }
 
@@ -48,7 +25,7 @@ function createServerFunction(
         Object.entries(vars || {}).map(([name, value]) => {
           return {
             name,
-            initializer: createLiteral(value.default),
+            initializer: cg.createLiteral(value.default),
           };
         })
       ),
@@ -58,7 +35,7 @@ function createServerFunction(
             return cg.createPropertySignature({
               name,
               type: value.enum
-                ? factory.createUnionTypeNode(createUnion(value.enum))
+                ? cg.createEnumTypeNode(value.enum)
                 : factory.createUnionTypeNode([
                     cg.keywordType.string,
                     cg.keywordType.number,
@@ -99,13 +76,13 @@ function serverName(server: OpenAPIV3.ServerObject, index: number) {
     : `server${index + 1}`;
 }
 
-export default function generateServers(servers: OpenAPIV3.ServerObject[]) {
-  const props = servers.map((server, i) => {
-    return [serverName(server, i), generateServerExpression(server)] as [
-      string,
-      ts.Expression
-    ];
-  });
-
-  return cg.createObjectLiteral(props);
+export default function generateServers(
+  servers: OpenAPIV3.ServerObject[]
+): ts.ObjectLiteralExpression {
+  return cg.createObjectLiteral(
+    servers.map((server, i) => [
+      serverName(server, i),
+      generateServerExpression(server),
+    ])
+  );
 }

--- a/src/codegen/tscodegen.ts
+++ b/src/codegen/tscodegen.ts
@@ -1,16 +1,6 @@
 import fs from "fs";
 import ts, { factory } from "typescript";
 
-ts.parseIsolatedEntityName;
-type KeywordTypeName =
-  | "any"
-  | "number"
-  | "object"
-  | "string"
-  | "boolean"
-  | "undefined"
-  | "null";
-
 export const questionToken = factory.createToken(ts.SyntaxKind.QuestionToken);
 
 export function createQuestionToken(token?: boolean | ts.QuestionToken) {
@@ -19,45 +9,47 @@ export function createQuestionToken(token?: boolean | ts.QuestionToken) {
   return token;
 }
 
-export function createKeywordType(type: KeywordTypeName) {
-  switch (type) {
-    case "any":
-      return factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
-    case "number":
-      return factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
-    case "object":
-      return factory.createKeywordTypeNode(ts.SyntaxKind.ObjectKeyword);
-    case "string":
-      return factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
-    case "boolean":
-      return factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
-    case "undefined":
-      return factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword);
-    case "null":
-      return factory.createLiteralTypeNode(
-        ts.factory.createToken(ts.SyntaxKind.NullKeyword)
-      );
-  }
-}
-
-export const keywordType: {
-  [type: string]: ts.KeywordTypeNode | ts.LiteralTypeNode;
-} = {
+export const keywordType = {
   any: factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
   number: factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
   object: factory.createKeywordTypeNode(ts.SyntaxKind.ObjectKeyword),
   string: factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
   boolean: factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
   undefined: factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
-  null: factory.createLiteralTypeNode(
-    ts.factory.createToken(ts.SyntaxKind.NullKeyword)
-  ),
+  void: factory.createKeywordTypeNode(ts.SyntaxKind.VoidKeyword),
+  null: factory.createLiteralTypeNode(factory.createNull()),
 };
+
+type KeywordTypeName = keyof typeof keywordType;
+
+export function createKeywordType(type: KeywordTypeName) {
+  return keywordType[type];
+}
 
 export const modifier = {
   async: factory.createModifier(ts.SyntaxKind.AsyncKeyword),
   export: factory.createModifier(ts.SyntaxKind.ExportKeyword),
 };
+
+export function createLiteral(v: string | boolean | number) {
+  switch (typeof v) {
+    case "string":
+      return factory.createStringLiteral(v);
+    case "boolean":
+      return v ? factory.createTrue() : factory.createFalse();
+    case "number":
+      return factory.createNumericLiteral(String(v));
+  }
+}
+
+export function createEnumTypeNode(values: Array<string | boolean | number>) {
+  const types = values.map((v) =>
+    v === null
+      ? keywordType.null
+      : factory.createLiteralTypeNode(createLiteral(v))
+  );
+  return types.length > 1 ? factory.createUnionTypeNode(types) : types[0];
+}
 
 export function createTypeAliasDeclaration({
   decorators,


### PR DESCRIPTION
Fixes #237 

`keywordType`
- Removed the TypeScript type on `const keywordType` so that a more specific type can be inferred.
- Add `keywordType.void` which was previously used but never defined.
- Refactor `function createKeywordType` to use `keywordType` internally.
- Derive the `type KeywordTypeName` from `keyof typeof keywordType` instead of typing out all the strings.
- Swapped lines 415 and 416 in `generate.ts` so that the second line gets a narrowed type.  This avoids TS errors in 4.6 but might be an error in lower 4.x versions, so I'm not sure if I should put an `as` assertion there?

`createEnumTypeNode`
- Combine enum creating logic from `generateServers.ts` and `generate.ts`.
- Move local function `createLiteral` from `generateServers.ts` into `tscodegen.ts` so that it can be reused.
- Create new utility `createEnumTypeNode` in `tscodegen.ts` which replaces the block of code in `generate.ts` 394-408 and the local function `createUnion` in `generateServers.ts`.

Misc
- `generateServers.ts`
  - Use existing utility function `cg.createTemplateString` inside of `createTemplate`.
  - Move the `props` variable (line 103) inside of the function call to eliminate the `as` assertion.
- `generate.ts`
  - Added some return types on methods and replaced a few `: any` with specific types.
- `tscodegen.ts`
  - Removed the `ts.parseIsolatedEntityName;` at the top of the file which I think is a mistake?  It was added [here](https://github.com/cellular/oazapfts/commit/c3c33f8ed285ff6f3e84b375785417dc06b141df).

~~It looks like I made way more changes because of prettier 🤷‍♀️ Maybe I should make an additional PR that just applies prettier to `src/codegen/generate.ts` and have that be merged first?~~