### PR TITLE
feat: expose response headers

### DIFF
--- a/demo/api.test.ts
+++ b/demo/api.test.ts
@@ -327,4 +327,13 @@ describe("Blob", () => {
       message: "OK",
     });
   });
+
+  describe("headers", () => {
+    it("should return headers", async () => {
+      const res = await api.getPetById(1);
+      expect(res.headers.get("x-powered-by")).toBe(
+        "jormaechea/open-api-mocker"
+      );
+    });
+  });
 });

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -23,6 +23,8 @@ type FormRequestOpts = RequestOpts & {
 
 export type ApiResponse = { status: number; data?: any };
 
+export type WithHeaders<T extends ApiResponse> = T & { headers: Headers };
+
 type MultipartRequestOpts = RequestOpts & {
   body?: Record<string, string | Blob | undefined | any>;
 };
@@ -37,6 +39,7 @@ export function runtime(defaults: RequestOpts) {
 
     return {
       status: res.status,
+      headers: res.headers,
       contentType: res.headers.get("content-type"),
       data,
     };
@@ -46,11 +49,11 @@ export function runtime(defaults: RequestOpts) {
     url: string,
     req: FetchRequestOpts = {}
   ) {
-    const { status, contentType, data } = await fetchText(url, {
+    const { status, headers, contentType, data } = await fetchText(url, {
       ...req,
       headers: {
-        ...req.headers,
         Accept: "application/json",
+        ...req.headers,
       },
     });
 
@@ -65,10 +68,14 @@ export function runtime(defaults: RequestOpts) {
       : false;
 
     if (isJson) {
-      return { status, data: data ? JSON.parse(data) : null } as T;
+      return {
+        status,
+        headers,
+        data: data ? JSON.parse(data) : null,
+      } as WithHeaders<T>;
     }
 
-    return { status, data } as T;
+    return { status, headers, data } as WithHeaders<T>;
   }
 
   async function fetchBlob<T extends ApiResponse>(
@@ -80,7 +87,7 @@ export function runtime(defaults: RequestOpts) {
     try {
       data = await res.blob();
     } catch (err) {}
-    return { status: res.status, data } as T;
+    return { status: res.status, headers: res.headers, data } as WithHeaders<T>;
   }
 
   async function doFetch(url: string, req: FetchRequestOpts = {}) {


### PR DESCRIPTION
This PR has the same intention as #87 but does not change any of the generated types, only the runtime.

I thought about @jonkoops' [comment](https://github.com/oazapfts/oazapfts/pull/87#discussion_r910902783) about exposing the whole request instead of just the headers, but didn't like the fact that one could get hold of the body this way. I also prefer the DX of writing `res.headers` rather than `res.response.headers`.