### PR TITLE
feat: support unknown json types

### DIFF
--- a/src/codegen/generate.test.ts
+++ b/src/codegen/generate.test.ts
@@ -1,4 +1,8 @@
-import ApiGenerator, { getOperationName } from "./generate";
+import ApiGenerator, {
+  getOperationName,
+  isJsonMimeType,
+  isMimeType,
+} from "./generate";
 import { printAst } from "./index";
 import SwaggerParser from "@apidevtools/swagger-parser";
 import { OpenAPIV3 } from "openapi-types";
@@ -16,6 +20,25 @@ describe("getOperationName", () => {
     expect(
       getOperationName("GET", "/pets", "API\\PetController::listPetAction")
     ).toEqual("getPets");
+  });
+});
+
+describe("content types", () => {
+  it("should identify strings that look like mime types", () => {
+    expect(isMimeType("*/*")).toBe(true);
+    expect(isMimeType("foo/bar")).toBe(true);
+    expect(isMimeType("foo/bar+baz")).toBe(true);
+    expect(isMimeType(undefined)).toBe(false);
+    expect(isMimeType("")).toBe(false);
+    expect(isMimeType("foo")).toBe(false);
+    expect(isMimeType("foo/bar/boo")).toBe(false);
+  });
+
+  it("should treat some content types as json", () => {
+    expect(isJsonMimeType("application/json")).toBe(true);
+    expect(isJsonMimeType("application/json+foo")).toBe(true);
+    expect(isJsonMimeType("*/*")).toBe(true);
+    expect(isJsonMimeType("text/plain")).toBe(false);
   });
 });
 

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -75,12 +75,12 @@ export function getOperationName(
   return _.camelCase(`${verb} ${path}`);
 }
 
-export function isNullable(schema: any) {
-  return !!(schema && schema.nullable);
+export function isNullable(schema?: SchemaObject | OpenAPIV3.ReferenceObject) {
+  return schema && !isReference(schema) && schema.nullable;
 }
 
-export function isReference(obj: any): obj is OpenAPIV3.ReferenceObject {
-  return obj && "$ref" in obj;
+export function isReference(obj: unknown): obj is OpenAPIV3.ReferenceObject {
+  return typeof obj === "object" && obj !== null && "$ref" in obj;
 }
 
 //See https://swagger.io/docs/specification/using-ref/
@@ -756,7 +756,7 @@ export default class ApiGenerator {
         const [required, optional] = _.partition(parameters, "required");
 
         // convert parameter names to argument names ...
-        const argNames: any = {};
+        const argNames: Record<string, string> = {};
         parameters
           .map((p) => p.name)
           .sort((a, b) => a.length - b.length)

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -54,15 +54,7 @@ export function runtime(defaults: RequestOpts) {
       },
     });
 
-    const jsonTypes = [
-      "application/json",
-      "application/hal+json",
-      "application/problem+json",
-      "application/geo+json",
-    ];
-    const isJson = contentType
-      ? jsonTypes.some((mimeType) => contentType.includes(mimeType))
-      : false;
+    const isJson = contentType ? contentType.includes("json") : false;
 
     if (isJson) {
       return { status, data: data ? JSON.parse(data) : null } as T;


### PR DESCRIPTION
This PR addresses #46 (and other similar issues we had in the past). Instead of explicitly listing all kinds of application/json flavours, it checks if the content type contains the `json` token.