### PR TITLE
fix: integer enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 lib/
 node_modules/
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Where `<spec>` is the URL or local path of an OpenAPI or Swagger spec (in either
 
 Use the `useEnumType` option to generate typescript enums instead of union of values.
 
+if you are using `type: 'integer'` enum, you will set `x-enumNames` to set names for each enum value to generate valid TypeScript Enum.
+
 ## Consuming the generated API
 
 For each operation defined in the spec the generated API will export a function with a name matching the `operationId`. If no ID is specified, a reasonable name is generated from the HTTP verb and the path.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Where `<spec>` is the URL or local path of an OpenAPI or Swagger spec (in either
 
 Use the `useEnumType` option to generate typescript enums instead of union of values.
 
-if you are using `type: 'integer'` enum, you will set `x-enumNames` to set names for each enum value to generate valid TypeScript Enum.
+if you are using `type: 'integer'` enum, you will need to add `x-enumNames` property to set names for each enum value to generate valid TypeScript Enum.
 
 ## Consuming the generated API
 

--- a/demo/api.ts
+++ b/demo/api.ts
@@ -31,6 +31,7 @@ export type Pet = {
   status?: "available" | "pending" | "sold";
   animal?: true;
   size?: "P" | "M" | "G";
+  typeId?: 1 | 2 | 3 | 4 | 6 | 8;
 };
 export type ApiResponse = {
   code?: number;

--- a/demo/enumApi.ts
+++ b/demo/enumApi.ts
@@ -31,6 +31,7 @@ export type Pet = {
   status?: Status;
   animal?: true;
   size?: Size;
+  typeId?: TypeId;
 };
 export type ApiResponse = {
   code?: number;
@@ -591,6 +592,14 @@ export enum Size {
   P = 0,
   M = 1,
   G = 2,
+}
+export enum TypeId {
+  dog = 0,
+  cat = 1,
+  tiger = 2,
+  mouse = 3,
+  house = 4,
+  cattle = 5,
 }
 export enum Status2 {
   Placed = "Placed",

--- a/demo/optimisticApi.ts
+++ b/demo/optimisticApi.ts
@@ -31,6 +31,7 @@ export type Pet = {
   status?: "available" | "pending" | "sold";
   animal?: true;
   size?: "P" | "M" | "G";
+  typeId?: 1 | 2 | 3 | 4 | 6 | 8;
 };
 export type ApiResponse = {
   code?: number;

--- a/demo/petstore.json
+++ b/demo/petstore.json
@@ -1217,6 +1217,12 @@
             "description": "Size scale for pets",
             "enum": ["P", "M", "G"],
             "type": "number"
+          },
+          "typeId": {
+            "description": "integer test case for #349",
+            "enum": [1, 2, 3, 4, 6, 8],
+            "type": "integer",
+            "x-enumNames": ["dog", "cat", "tiger", "mouse", "house", "cattle"]
           }
         },
         "xml": {

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -553,17 +553,41 @@ export default class ApiGenerator {
 
     const values = schema.enum ? schema.enum : [];
 
+    const names = Object.entries(schema).find(
+      ([key, value]) => key === "x-enumNames"
+    )?.[1];
+
     const members = values.map((s, index) => {
+      if (schema.type === "number") {
+        console.log(s);
+        return factory.createEnumMember(
+          factory.createIdentifier(s),
+          factory.createNumericLiteral(index)
+        );
+      }
+
+      if (schema.type === "integer") {
+        if (!names) {
+          throw new Error(
+            "integer enum should have property `x-enumNames` as ts enum names"
+          );
+        }
+
+        return factory.createEnumMember(
+          factory.createIdentifier(names[index]),
+          factory.createNumericLiteral(index)
+        );
+      }
+
       if (schema.type === "boolean") {
         s = Boolean(s) ? "true" : "false";
       } else if (schema.type === "string") {
         s = _.upperFirst(s);
       }
+
       return factory.createEnumMember(
         factory.createIdentifier(s),
-        schema.type === "number" || schema.type === "integer"
-          ? factory.createNumericLiteral(index)
-          : factory.createStringLiteral(s)
+        factory.createStringLiteral(s)
       );
     });
     this.enumAliases.push(

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -559,7 +559,6 @@ export default class ApiGenerator {
 
     const members = values.map((s, index) => {
       if (schema.type === "number") {
-        console.log(s);
         return factory.createEnumMember(
           factory.createIdentifier(s),
           factory.createNumericLiteral(index)

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -553,9 +553,12 @@ export default class ApiGenerator {
 
     const values = schema.enum ? schema.enum : [];
 
-    const names = Object.entries(schema).find(
-      ([key, value]) => key === "x-enumNames"
-    )?.[1];
+    const names = (schema as Record<string, unknown>)["x-enumNames"] as
+      | Array<string>
+      | undefined;
+    if (names && !Array.isArray(names)) {
+      throw new Error("x-enumNames must be an array");
+    }
 
     const members = values.map((s, index) => {
       if (schema.type === "number") {

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -561,7 +561,7 @@ export default class ApiGenerator {
       }
       return factory.createEnumMember(
         factory.createIdentifier(s),
-        schema.type === "number"
+        schema.type === "number" || schema.type === "integer"
           ? factory.createNumericLiteral(index)
           : factory.createStringLiteral(s)
       );


### PR DESCRIPTION
fix case like this:

openapi type can be `number` or `integer`

```yaml
        state:
          title: CommentState
          example: 0
          enum:
            - 0
            - 1
            - 2
            - 5
            - 6
            - 7
          type: integer
          x-enumNames: [...]
          description: |-
```

close https://github.com/oazapfts/oazapfts/issues/348

there is no strandard way to set enum names in openapi 3.0.x but `x-enumNames` is common used, so this PR will require `x-enumNames` property as integer enum name in typescript Enum declare