### PR TITLE
Throw error with HTTP headers

### DIFF
--- a/src/runtime/index.test.ts
+++ b/src/runtime/index.test.ts
@@ -1,4 +1,5 @@
 import * as Oazapfts from ".";
+import { HttpError, ok } from "../";
 
 const oazapfts = Oazapfts.runtime({});
 
@@ -37,5 +38,32 @@ describe("request", () => {
 
     expect(customFetch).toHaveBeenCalledWith("foo/bar", expect.any(Object));
     expect(g.fetch).not.toHaveBeenCalled();
+  });
+
+  it("should throw error with headers", async () => {
+    const fn = () =>
+      ok(
+        oazapfts.fetchText("bar", {
+          fetch: async () => {
+            return new Response("", {
+              status: 401,
+              headers: { "x-request-id": "1234" },
+            });
+          },
+        })
+      );
+
+    let throwed;
+    let err: HttpError | undefined;
+    try {
+      await fn();
+    } catch (e) {
+      err = e as HttpError;
+      throwed = true;
+    }
+
+    expect(throwed).toBe(true);
+    expect(err).toBeInstanceOf(HttpError);
+    expect(err?.headers?.get("x-request-id")).toBe("1234");
   });
 });


### PR DESCRIPTION
close https://github.com/oazapfts/oazapfts/issues/390

I have a use case like this:


```ts
try {
  await ok(...);
} catch (e) {
  if (e instanceof HttpError) {
    console.log(e.headers.get("x-request-id"));
  }

  throw e;
}
```


`oazapfts.fetchText` and `oazapfts.fetchJson` already return response with headers, so it doesn't change generated code, only runtime code and types.