### PR TITLE
Handle nested objects and $refs in read-/writeonly types

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Options:
 --include, -i tag to include
 --optimistic
 --useEnumType
+--mergeReadWriteOnly
 ```
 
 Where `<spec>` is the URL or local path of an OpenAPI or Swagger spec (in either json or yml) and `<filename>` is the location of the `.ts` file to be generated. If the filename is omitted, the code is written to stdout.
@@ -44,6 +45,8 @@ Where `<spec>` is the URL or local path of an OpenAPI or Swagger spec (in either
 - `--optimistic` generare a client in [optimistic mode](#optimistic-mode)
 
 - `--useEnumType` generate enums instead of union types
+
+- `--mergeReadWriteOnly` by default oazapfs will generate separate types for read-only and write-only properties. This option will merge them into one type.
 
 ## Consuming the generated API
 

--- a/demo/api.test.ts
+++ b/demo/api.test.ts
@@ -108,6 +108,27 @@ describe("ok", () => {
     // @ts-expect-error (writeonly Property)
     type ReadHidden = api.PagedListOfProductRead["items"][number]["hidden"];
   });
+
+  it("handles mixed readonly and writeonly properties", async () => {
+    const base: api.ReadWriteMixed = {};
+    // @ts-expect-error (readonly Property)
+    base.message = "nope";
+    // @ts-expect-error (writeonly Property)
+    base.email = "hi@example.org";
+
+    const write: api.ReadWriteMixedWrite = {
+      email: "hi@example.org",
+      password: "123",
+    };
+    // @ts-expect-error (readonly Property)
+    write.message = "nope";
+
+    const read: api.ReadWriteMixedRead = {
+      message: "hi",
+    };
+    // @ts-expect-error (writeonly Property)
+    read.email = "hi@example.org";
+  });
 });
 
 describe("object query parameters", () => {

--- a/demo/api.ts
+++ b/demo/api.ts
@@ -100,6 +100,14 @@ export type PagedListOfProductWrite = {
   pageSize: number;
   totalCount: number;
 };
+export type ReadWriteMixed = {};
+export type ReadWriteMixedRead = {
+  message: string;
+};
+export type ReadWriteMixedWrite = {
+  email: string;
+  password: string;
+};
 /**
  * Update an existing pet
  */
@@ -653,12 +661,31 @@ export function productsCreateMany(
   body?: PagedListOfProductWrite | Pet,
   opts?: Oazapfts.RequestOpts,
 ) {
-  return oazapfts.fetchText(
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: {};
+  }>(
     "/issue-446",
     oazapfts.json({
       ...opts,
       method: "POST",
       body,
+    }),
+  );
+}
+export function readWriteMixed(
+  readWriteMixed?: ReadWriteMixedWrite,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: ReadWriteMixedRead;
+  }>(
+    "issue-453",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: readWriteMixed,
     }),
   );
 }

--- a/demo/api.ts
+++ b/demo/api.ts
@@ -61,6 +61,45 @@ export type Schema = string;
 export type Schema2 = number;
 export type Option = ("one" | "two" | "three")[];
 export type EnumToRef = "monkey" | "dog" | "cat";
+export type Product = {
+  name: string;
+  description: string;
+  currency: string;
+};
+export type ProductRead = {
+  id: string;
+  name: string;
+  description: string;
+  currency: string;
+  producerID: string;
+};
+export type ProductWrite = {
+  name: string;
+  description: string;
+  hidden?: boolean;
+  currency: string;
+};
+export type PagedListOfProduct = {
+  items: Product[];
+  totalPages: number;
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+};
+export type PagedListOfProductRead = {
+  items: ProductRead[];
+  totalPages: number;
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+};
+export type PagedListOfProductWrite = {
+  items: ProductWrite[];
+  totalPages: number;
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+};
 /**
  * Update an existing pet
  */
@@ -593,4 +632,33 @@ export function getIssue367(opts?: Oazapfts.RequestOpts) {
   }>("/issue367", {
     ...opts,
   });
+}
+export function productsGetAll(opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: PagedListOfProductRead;
+      }
+    | {
+        status: 210;
+        data: ProductRead & {
+          producerId: string;
+        };
+      }
+  >("/issue-446", {
+    ...opts,
+  });
+}
+export function productsCreateMany(
+  body?: PagedListOfProductWrite | Pet,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    "/issue-446",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body,
+    }),
+  );
 }

--- a/demo/enumApi.ts
+++ b/demo/enumApi.ts
@@ -60,6 +60,45 @@ export type User = {
 export type Schema = string;
 export type Schema2 = number;
 export type Option = ("one" | "two" | "three")[];
+export type Product = {
+  name: string;
+  description: string;
+  currency: string;
+};
+export type ProductRead = {
+  id: string;
+  name: string;
+  description: string;
+  currency: string;
+  producerID: string;
+};
+export type ProductWrite = {
+  name: string;
+  description: string;
+  hidden?: boolean;
+  currency: string;
+};
+export type PagedListOfProduct = {
+  items: Product[];
+  totalPages: number;
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+};
+export type PagedListOfProductRead = {
+  items: ProductRead[];
+  totalPages: number;
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+};
+export type PagedListOfProductWrite = {
+  items: ProductWrite[];
+  totalPages: number;
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+};
 /**
  * Update an existing pet
  */
@@ -592,6 +631,35 @@ export function getIssue367(opts?: Oazapfts.RequestOpts) {
   }>("/issue367", {
     ...opts,
   });
+}
+export function productsGetAll(opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: PagedListOfProductRead;
+      }
+    | {
+        status: 210;
+        data: ProductRead & {
+          producerId: string;
+        };
+      }
+  >("/issue-446", {
+    ...opts,
+  });
+}
+export function productsCreateMany(
+  body?: PagedListOfProductWrite | Pet,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    "/issue-446",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body,
+    }),
+  );
 }
 export enum Status {
   Available = "available",

--- a/demo/enumApi.ts
+++ b/demo/enumApi.ts
@@ -99,6 +99,14 @@ export type PagedListOfProductWrite = {
   pageSize: number;
   totalCount: number;
 };
+export type ReadWriteMixed = {};
+export type ReadWriteMixedRead = {
+  message: string;
+};
+export type ReadWriteMixedWrite = {
+  email: string;
+  password: string;
+};
 /**
  * Update an existing pet
  */
@@ -652,12 +660,31 @@ export function productsCreateMany(
   body?: PagedListOfProductWrite | Pet,
   opts?: Oazapfts.RequestOpts,
 ) {
-  return oazapfts.fetchText(
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: {};
+  }>(
     "/issue-446",
     oazapfts.json({
       ...opts,
       method: "POST",
       body,
+    }),
+  );
+}
+export function readWriteMixed(
+  readWriteMixed?: ReadWriteMixedWrite,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: ReadWriteMixedRead;
+  }>(
+    "issue-453",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: readWriteMixed,
     }),
   );
 }

--- a/demo/mergedReadWriteApi.ts
+++ b/demo/mergedReadWriteApi.ts
@@ -1,0 +1,596 @@
+/**
+ * Swagger Petstore
+ * 1.0.0
+ * DO NOT MODIFY - This file has been generated using oazapfts.
+ * See https://www.npmjs.com/package/oazapfts
+ */
+import * as Oazapfts from "oazapfts/lib/runtime";
+import * as QS from "oazapfts/lib/runtime/query";
+export const defaults: Oazapfts.RequestOpts = {
+  baseUrl: "https://petstore.swagger.io/v2",
+};
+const oazapfts = Oazapfts.runtime(defaults);
+export const servers = {
+  server1: "https://petstore.swagger.io/v2",
+  server2: "http://petstore.swagger.io/v2",
+};
+export type Category = {
+  id?: number;
+  name?: string;
+};
+export type Tag = {
+  id?: number;
+  name?: string;
+};
+export type Pet = {
+  id?: number;
+  category?: Category;
+  name: string;
+  photoUrls: string[];
+  tags?: Tag[];
+  status?: "available" | "pending" | "sold" | "private" | "10percent";
+  animal?: true;
+  size?: "P" | "M" | "G" | "0";
+  typeId?: 1 | 2 | 3 | 4 | 6 | 8;
+};
+export type ApiResponse = {
+  code?: number;
+  type?: string;
+  message?: string;
+};
+export type Order = {
+  id?: number;
+  petId?: number;
+  quantity?: number;
+  shipDate?: string;
+  status?: "placed" | "approved" | "delivered";
+  complete?: boolean;
+};
+export type User = {
+  id?: number;
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  password?: string;
+  phone?: string;
+  userStatus?: number;
+  category?: "rich" | "wealthy" | "poor";
+};
+export type Schema = string;
+export type Schema2 = number;
+export type Option = ("one" | "two" | "three")[];
+export type EnumToRef = "monkey" | "dog" | "cat";
+/**
+ * Update an existing pet
+ */
+export function updatePet(pet: Pet, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 204;
+        data: string;
+      }
+    | {
+        status: 404;
+        data: string;
+      }
+    | {
+        status: number;
+        data: {
+          errors?: string[];
+        };
+      }
+  >(
+    "/pet",
+    oazapfts.json({
+      ...opts,
+      method: "PUT",
+      body: pet,
+    }),
+  );
+}
+/**
+ * Add a new pet to the store
+ */
+export function addPet(pet: Pet, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: Pet;
+      }
+    | {
+        status: 201;
+        data: {
+          id?: string;
+        };
+      }
+  >(
+    "/pet",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: pet,
+    }),
+  );
+}
+/**
+ * Finds Pets by status
+ */
+export function findPetsByStatus(
+  status: ("available" | "pending" | "sold")[],
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: Pet[];
+      }
+    | {
+        status: 400;
+        data: string;
+      }
+  >(
+    `/pet/findByStatus${QS.query(
+      QS.explode({
+        status,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * Finds Pets by tags
+ */
+export function findPetsByTags(tags: string[], opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: Pet[];
+      }
+    | {
+        status: 400;
+        data: string;
+      }
+  >(
+    `/pet/findByTags${QS.query(
+      QS.explode({
+        tags,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * Find pet by ID
+ */
+export function getPetById(petId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: Pet;
+      }
+    | {
+        status: 400;
+        data: string;
+      }
+    | {
+        status: 404;
+      }
+  >(`/pet/${encodeURIComponent(petId)}`, {
+    ...opts,
+  });
+}
+/**
+ * Updates a pet in the store with form data
+ */
+export function updatePetWithForm(
+  petId: number,
+  body?: {
+    name?: string;
+    status?: string;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    `/pet/${encodeURIComponent(petId)}`,
+    oazapfts.form({
+      ...opts,
+      method: "POST",
+      body,
+    }),
+  );
+}
+/**
+ * Deletes a pet
+ */
+export function deletePet(
+  petId: number,
+  {
+    apiKey,
+  }: {
+    apiKey?: string;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(`/pet/${encodeURIComponent(petId)}`, {
+    ...opts,
+    method: "DELETE",
+    headers: {
+      ...(opts && opts.headers),
+      api_key: apiKey,
+    },
+  });
+}
+/**
+ * uploads an image
+ */
+export function uploadFile(
+  petId: number,
+  body?: {
+    additionalMetadata?: string;
+    file?: Blob;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: ApiResponse;
+  }>(
+    `/pet/${encodeURIComponent(petId)}/uploadImage`,
+    oazapfts.multipart({
+      ...opts,
+      method: "POST",
+      body,
+    }),
+  );
+}
+export function customizePet(
+  petId: number,
+  {
+    furColor,
+    color,
+    xColorOptions,
+  }: {
+    furColor?: string;
+    color?: string;
+    xColorOptions?: boolean;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    `/pet/${encodeURIComponent(petId)}/customize${QS.query(
+      QS.explode({
+        "fur.color": furColor,
+        color,
+      }),
+    )}`,
+    {
+      ...opts,
+      method: "POST",
+      headers: {
+        ...(opts && opts.headers),
+        "x-color-options": xColorOptions,
+      },
+    },
+  );
+}
+/**
+ * Returns pet inventories by status
+ */
+export function getInventory(opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: {
+      [key: string]: number;
+    };
+  }>("/store/inventory", {
+    ...opts,
+  });
+}
+/**
+ * Place an order for a pet
+ */
+export function placeOrder(order: Order, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: Order;
+      }
+    | {
+        status: 400;
+        data: string;
+      }
+  >(
+    "/store/order",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: order,
+    }),
+  );
+}
+/**
+ * Find purchase order by ID
+ */
+export function getOrderById(orderId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: Order;
+      }
+    | {
+        status: 400;
+        data: string;
+      }
+    | {
+        status: 404;
+        data: string;
+      }
+  >(`/store/order/${encodeURIComponent(orderId)}`, {
+    ...opts,
+  });
+}
+/**
+ * Delete purchase order by ID
+ */
+export function deleteOrder(orderId: number, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchText(`/store/order/${encodeURIComponent(orderId)}`, {
+    ...opts,
+    method: "DELETE",
+  });
+}
+/**
+ * Create user
+ */
+export function createUser(user: User, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchText(
+    "/user",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: user,
+    }),
+  );
+}
+/**
+ * Creates list of users with given input array
+ */
+export function createUsersWithArrayInput(
+  body: User[],
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    "/user/createWithArray",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body,
+    }),
+  );
+}
+/**
+ * Creates list of users with given input array
+ */
+export function createUsersWithListInput(
+  body: User[],
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    "/user/createWithList",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body,
+    }),
+  );
+}
+/**
+ * Logs user into the system
+ */
+export function loginUser(
+  username: string,
+  password: string,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: string;
+      }
+    | {
+        status: 400;
+        data: string;
+      }
+  >(
+    `/user/login${QS.query(
+      QS.explode({
+        username,
+        password,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * Logs out current logged in user session
+ */
+export function logoutUser(opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchText("/user/logout", {
+    ...opts,
+  });
+}
+/**
+ * Get user by user name
+ */
+export function getUserByName(username: string, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: User;
+      }
+    | {
+        status: 400;
+        data: string;
+      }
+    | {
+        status: 404;
+        data: string;
+      }
+  >(`/user/${encodeURIComponent(username)}`, {
+    ...opts,
+  });
+}
+/**
+ * Updated user
+ */
+export function updateUser(
+  username: string,
+  user: User,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    `/user/${encodeURIComponent(username)}`,
+    oazapfts.json({
+      ...opts,
+      method: "PUT",
+      body: user,
+    }),
+  );
+}
+/**
+ * Delete user
+ */
+export function deleteUser(username: string, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchText(`/user/${encodeURIComponent(username)}`, {
+    ...opts,
+    method: "DELETE",
+  });
+}
+export function getIssue31ByFoo(
+  foo: string,
+  {
+    bar,
+    baz,
+    boo,
+  }: {
+    bar?: Schema;
+    baz?: number;
+    boo?: Schema2;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    `/issue31/${encodeURIComponent(foo)}${QS.query(
+      QS.explode({
+        bar,
+        baz,
+        boo,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+export function getObjectParameters(
+  {
+    defaultArray,
+    explodedFormArray,
+    commaArray,
+    defaultSpaceDelimited,
+    explodedSpaceDelimited,
+    spaceDelimited,
+    defaultPipeDelimited,
+    explodedPipeDelimited,
+    pipeDelimited,
+    defaultObject,
+    explodedFormObject,
+    commaObject,
+    deepObject,
+  }: {
+    defaultArray?: Option;
+    explodedFormArray?: Option;
+    commaArray?: Option;
+    defaultSpaceDelimited?: Option;
+    explodedSpaceDelimited?: Option;
+    spaceDelimited?: Option;
+    defaultPipeDelimited?: Option;
+    explodedPipeDelimited?: Option;
+    pipeDelimited?: Option;
+    defaultObject?: Tag;
+    explodedFormObject?: Tag;
+    commaObject?: Tag;
+    deepObject?: Tag;
+  } = {},
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    `/object-parameters${QS.query(
+      QS.explode({
+        defaultArray,
+        explodedFormArray,
+        defaultSpaceDelimited,
+        explodedSpaceDelimited,
+        defaultPipeDelimited,
+        explodedPipeDelimited,
+        defaultObject,
+        explodedFormObject,
+      }),
+      QS.form({
+        commaArray,
+        commaObject,
+      }),
+      QS.space({
+        spaceDelimited,
+      }),
+      QS.pipe({
+        pipeDelimited,
+      }),
+      QS.deep({
+        deepObject,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * uploads an image in png format
+ */
+export function uploadPng(body?: Blob, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: ApiResponse;
+  }>("/uploadPng", {
+    ...opts,
+    method: "POST",
+    body,
+  });
+}
+export function issue330(body?: string, opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchText(
+    "issue330",
+    oazapfts.json({
+      ...opts,
+      method: "PUT",
+      body,
+    }),
+  );
+}
+export function getIssue367(opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: {
+      foo?: EnumToRef;
+    };
+  }>("/issue367", {
+    ...opts,
+  });
+}

--- a/demo/mergedReadWriteApi.ts
+++ b/demo/mergedReadWriteApi.ts
@@ -61,6 +61,21 @@ export type Schema = string;
 export type Schema2 = number;
 export type Option = ("one" | "two" | "three")[];
 export type EnumToRef = "monkey" | "dog" | "cat";
+export type Product = {
+  id: string;
+  name: string;
+  description: string;
+  hidden?: boolean;
+  currency: string;
+  producerID: string;
+};
+export type PagedListOfProduct = {
+  items: Product[];
+  totalPages: number;
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+};
 /**
  * Update an existing pet
  */
@@ -593,4 +608,34 @@ export function getIssue367(opts?: Oazapfts.RequestOpts) {
   }>("/issue367", {
     ...opts,
   });
+}
+export function productsGetAll(opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: PagedListOfProduct;
+      }
+    | {
+        status: 210;
+        data: Product & {
+          producerId: string;
+          hidden?: boolean;
+        };
+      }
+  >("/issue-446", {
+    ...opts,
+  });
+}
+export function productsCreateMany(
+  body?: PagedListOfProduct | Pet,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    "/issue-446",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body,
+    }),
+  );
 }

--- a/demo/mergedReadWriteApi.ts
+++ b/demo/mergedReadWriteApi.ts
@@ -76,6 +76,11 @@ export type PagedListOfProduct = {
   pageSize: number;
   totalCount: number;
 };
+export type ReadWriteMixed = {
+  email: string;
+  password: string;
+  message: string;
+};
 /**
  * Update an existing pet
  */
@@ -630,12 +635,31 @@ export function productsCreateMany(
   body?: PagedListOfProduct | Pet,
   opts?: Oazapfts.RequestOpts,
 ) {
-  return oazapfts.fetchText(
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: {};
+  }>(
     "/issue-446",
     oazapfts.json({
       ...opts,
       method: "POST",
       body,
+    }),
+  );
+}
+export function readWriteMixed(
+  readWriteMixed?: ReadWriteMixed,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: ReadWriteMixed;
+  }>(
+    "issue-453",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: readWriteMixed,
     }),
   );
 }

--- a/demo/optimisticApi.ts
+++ b/demo/optimisticApi.ts
@@ -100,6 +100,14 @@ export type PagedListOfProductWrite = {
   pageSize: number;
   totalCount: number;
 };
+export type ReadWriteMixed = {};
+export type ReadWriteMixedRead = {
+  message: string;
+};
+export type ReadWriteMixedWrite = {
+  email: string;
+  password: string;
+};
 /**
  * Update an existing pet
  */
@@ -708,12 +716,33 @@ export function productsCreateMany(
   opts?: Oazapfts.RequestOpts,
 ) {
   return oazapfts.ok(
-    oazapfts.fetchText(
+    oazapfts.fetchJson<{
+      status: 200;
+      data: {};
+    }>(
       "/issue-446",
       oazapfts.json({
         ...opts,
         method: "POST",
         body,
+      }),
+    ),
+  );
+}
+export function readWriteMixed(
+  readWriteMixed?: ReadWriteMixedWrite,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.ok(
+    oazapfts.fetchJson<{
+      status: 200;
+      data: ReadWriteMixedRead;
+    }>(
+      "issue-453",
+      oazapfts.json({
+        ...opts,
+        method: "POST",
+        body: readWriteMixed,
       }),
     ),
   );

--- a/demo/optimisticApi.ts
+++ b/demo/optimisticApi.ts
@@ -61,6 +61,45 @@ export type Schema = string;
 export type Schema2 = number;
 export type Option = ("one" | "two" | "three")[];
 export type EnumToRef = "monkey" | "dog" | "cat";
+export type Product = {
+  name: string;
+  description: string;
+  currency: string;
+};
+export type ProductRead = {
+  id: string;
+  name: string;
+  description: string;
+  currency: string;
+  producerID: string;
+};
+export type ProductWrite = {
+  name: string;
+  description: string;
+  hidden?: boolean;
+  currency: string;
+};
+export type PagedListOfProduct = {
+  items: Product[];
+  totalPages: number;
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+};
+export type PagedListOfProductRead = {
+  items: ProductRead[];
+  totalPages: number;
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+};
+export type PagedListOfProductWrite = {
+  items: ProductWrite[];
+  totalPages: number;
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+};
 /**
  * Update an existing pet
  */
@@ -644,5 +683,38 @@ export function getIssue367(opts?: Oazapfts.RequestOpts) {
     }>("/issue367", {
       ...opts,
     }),
+  );
+}
+export function productsGetAll(opts?: Oazapfts.RequestOpts) {
+  return oazapfts.ok(
+    oazapfts.fetchJson<
+      | {
+          status: 200;
+          data: PagedListOfProductRead;
+        }
+      | {
+          status: 210;
+          data: ProductRead & {
+            producerId: string;
+          };
+        }
+    >("/issue-446", {
+      ...opts,
+    }),
+  );
+}
+export function productsCreateMany(
+  body?: PagedListOfProductWrite | Pet,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.ok(
+    oazapfts.fetchText(
+      "/issue-446",
+      oazapfts.json({
+        ...opts,
+        method: "POST",
+        body,
+      }),
+    ),
   );
 }

--- a/demo/petstore.json
+++ b/demo/petstore.json
@@ -1088,10 +1088,158 @@
           }
         }
       }
+    },
+    "/issue-446": {
+      "get": {
+        "operationId": "Products_GetAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedListOfProduct"
+                }
+              }
+            }
+          },
+          "210": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Product"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": ["producerId"],
+                      "properties": {
+                        "producerId": {
+                          "type": "string",
+                          "minLength": 1,
+                          "readOnly": true
+                        },
+                        "hidden": {
+                          "type": "boolean",
+                          "writeOnly": true
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+
+      "post": {
+        "operationId": "Products_CreateMany",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/PagedListOfProduct"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
+      "PagedListOfProduct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "items",
+          "totalPages",
+          "pageIndex",
+          "pageSize",
+          "totalCount"
+        ],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Product"
+            }
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageIndex": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "Product": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "name", "description", "currency", "producerID"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "readOnly": true,
+            "format": "guid",
+            "minLength": 1
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "hidden": {
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "currency": {
+            "type": "string",
+            "minLength": 1
+          },
+          "producerID": {
+            "type": "string",
+            "readOnly": true,
+            "format": "guid",
+            "minLength": 1
+          }
+        }
+      },
       "Order": {
         "type": "object",
         "properties": {

--- a/demo/petstore.json
+++ b/demo/petstore.json
@@ -1136,7 +1136,6 @@
           }
         }
       },
-
       "post": {
         "operationId": "Products_CreateMany",
         "parameters": [],
@@ -1159,9 +1158,40 @@
         "responses": {
           "200": {
             "description": "A successful response.",
-            "schema": {
-              "type": "object",
-              "properties": {}
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "issue-453": {
+      "post": {
+        "operationId": "ReadWriteMixed",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReadWriteMixed"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadWriteMixed"
+                }
+              }
             }
           }
         }
@@ -1170,6 +1200,24 @@
   },
   "components": {
     "schemas": {
+      "ReadWriteMixed": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "writeOnly": true
+          },
+          "password": {
+            "type": "string",
+            "writeOnly": true
+          },
+          "message": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "required": ["email", "password", "message"]
+      },
       "PagedListOfProduct": {
         "type": "object",
         "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:unit": "jest",
     "test:e2e": "npm run generate-demo && with-server 'cd demo && jest'",
     "start": "open-api-mocker -p $PORT -s demo/petstore.json",
-    "generate-demo": "npm run prepare && ./lib/codegen/cli.js ./demo/petstore.json ./demo/api.ts && ./lib/codegen/cli.js --optimistic ./demo/petstore.json ./demo/optimisticApi.ts && ./lib/codegen/cli.js --useEnumType ./demo/petstore.json ./demo/enumApi.ts && prettier -w demo",
+    "generate-demo": "npm run prepare && ./lib/codegen/cli.js ./demo/petstore.json ./demo/api.ts && ./lib/codegen/cli.js ./demo/petstore.json --mergeReadWriteOnly ./demo/mergedReadWriteApi.ts && ./lib/codegen/cli.js --optimistic ./demo/petstore.json ./demo/optimisticApi.ts && ./lib/codegen/cli.js --useEnumType ./demo/petstore.json ./demo/enumApi.ts && prettier -w demo",
     "prepare": "npm run build && chmod +x ./lib/codegen/cli.js && husky install"
   },
   "keywords": [

--- a/src/codegen/__fixtures__/readOnlyWriteOnly.yaml
+++ b/src/codegen/__fixtures__/readOnlyWriteOnly.yaml
@@ -28,8 +28,108 @@ paths:
                 $ref: "#/components/schemas/ExampleSchema"
           description: OK
       operationId: setExample
+  /example-extend:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExampleParentSchema"
+          description: OK
+      operationId: getPatentExampleExtend
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExampleParentSchema"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExampleBaseSchema"
+          description: OK
+      operationId: setPatentExampleExtend
+  /example-all-of:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ExampleSchema"
+                  - $ref: "#/components/schemas/ExampleBaseSchema"
+          description: OK
+      operationId: getExampleAllOf
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/ExampleSchema"
+                - $ref: "#/components/schemas/ExampleBaseSchema"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExampleBaseSchema"
+          description: OK
+      operationId: setExampleAllOf
+  /example-one-of:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/ExampleSchema"
+                  - $ref: "#/components/schemas/ExampleBaseSchema"
+          description: OK
+      operationId: getExampleOneOf
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/ExampleSchema"
+                - $ref: "#/components/schemas/ExampleBaseSchema"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExampleBaseSchema"
+          description: OK
+      operationId: setExampleOneOf
 components:
   schemas:
+    ExampleBaseSchema:
+      description: ""
+      required:
+        - id
+      type: object
+      properties:
+        always_present:
+          description: ""
+          type: string
+    ExampleParentSchema:
+      description: ""
+      required:
+        - child_schema
+      type: object
+      properties:
+        child_schema:
+          $ref: "#/components/schemas/ExampleSchema"
     ExampleSchema:
       description: ""
       required:

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -753,11 +753,8 @@ export default class ApiGenerator {
           return !isReadOnly && !isWriteOnly;
       }
     });
-    // By filtering by readOnly/writeOnly props, we may have filtered out all props in schemas
-    const hasFilteredAllProps = filteredPropertyNames.length === 0;
-    const names = hasFilteredAllProps ? propertyNames : filteredPropertyNames;
 
-    const members: ts.TypeElement[] = names.map((name) => {
+    const members: ts.TypeElement[] = filteredPropertyNames.map((name) => {
       const schema = props[name];
       const isRequired = required && required.includes(name);
       let type = this.getTypeFromSchema(schema, name, onlyMode);


### PR DESCRIPTION
Supersedes: https://github.com/oazapfts/oazapfts/pull/450

The existing implementation for [handling read-/writeonly](https://github.com/oazapfts/oazapfts/issues/382) ignored `array`, `$ref` and other nested types, which caused some properties to become missing on those nested objects.

This fix now always creates all applicable read/write extensions for a type and takes nested/linked types into account when determining if a type has readonly or writeonly qualities.

Also keeps the `--mergeReadWriteOnly` flag from #450 around to support opting out of the the behavior altogether.

@cvereterra would you mind having a look on this?

Also PTAL/FYI @fgnass @jonkoops @ehvattum 
