### PR TITLE
Customize 'Content-Type' header

### DIFF
--- a/src/runtime/index.test.ts
+++ b/src/runtime/index.test.ts
@@ -66,4 +66,22 @@ describe("request", () => {
     expect(err).toBeInstanceOf(HttpError);
     expect(err?.headers?.get("x-request-id")).toBe("1234");
   });
+
+  it("should allow 'Content-Type' header to be customized", async () => {
+    const jsonUTF8ContentType = "application/json; charset=UTF-8";
+    const formUTF8ContentType =
+      "application/x-www-form-urlencoded; charset=UTF-8";
+
+    const jsonResponse = oazapfts.json({
+      body: { value: "body value" },
+      headers: { "Content-Type": jsonUTF8ContentType },
+    });
+    const formResponse = oazapfts.form({
+      body: { value: "body value" },
+      headers: { "Content-Type": formUTF8ContentType },
+    });
+
+    expect(jsonResponse.headers["Content-Type"]).toEqual(jsonUTF8ContentType);
+    expect(formResponse.headers["Content-Type"]).toEqual(formUTF8ContentType);
+  });
 });

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -100,15 +100,15 @@ export function runtime(defaults: RequestOpts) {
     return res;
   }
 
-  function hasJsonContentType(contentTypeHeader: string) {
-    console.log("hasJsonContentType");
+  /* TODO: maybe we want to get rid of this checks (ensureJsonContentType & ensureFormContentType)
+  in a future major release (ref https://github.com/oazapfts/oazapfts/pull/456) */
+  function ensureJsonContentType(contentTypeHeader: string) {
     return contentTypeHeader?.match(/\bjson\b/i)
       ? contentTypeHeader
       : "application/json";
   }
 
-  function hasFormContentType(contentTypeHeader: string) {
-    console.log("hasFormContentType");
+  function ensureFormContentType(contentTypeHeader: string) {
     return contentTypeHeader?.startsWith("application/x-www-form-urlencoded")
       ? contentTypeHeader
       : "application/x-www-form-urlencoded";
@@ -126,7 +126,9 @@ export function runtime(defaults: RequestOpts) {
         ...(body != null && { body: JSON.stringify(body) }),
         headers: {
           ...headers,
-          "Content-Type": hasJsonContentType(String(headers?.["Content-Type"])),
+          "Content-Type": ensureJsonContentType(
+            String(headers?.["Content-Type"]),
+          ),
         },
       };
     },
@@ -137,7 +139,9 @@ export function runtime(defaults: RequestOpts) {
         ...(body != null && { body: qs.form(body) }),
         headers: {
           ...headers,
-          "Content-Type": hasFormContentType(String(headers?.["Content-Type"])),
+          "Content-Type": ensureFormContentType(
+            String(headers?.["Content-Type"]),
+          ),
         },
       };
     },

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -111,8 +111,8 @@ export function runtime(defaults: RequestOpts) {
         ...req,
         ...(body != null && { body: JSON.stringify(body) }),
         headers: {
-          ...headers,
           "Content-Type": "application/json",
+          ...headers,
         },
       };
     },

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -100,6 +100,20 @@ export function runtime(defaults: RequestOpts) {
     return res;
   }
 
+  function hasJsonContentType(contentTypeHeader: string) {
+    console.log("hasJsonContentType");
+    return contentTypeHeader?.match(/\bjson\b/i)
+      ? contentTypeHeader
+      : "application/json";
+  }
+
+  function hasFormContentType(contentTypeHeader: string) {
+    console.log("hasFormContentType");
+    return contentTypeHeader?.startsWith("application/x-www-form-urlencoded")
+      ? contentTypeHeader
+      : "application/x-www-form-urlencoded";
+  }
+
   return {
     ok,
     fetchText,
@@ -111,8 +125,8 @@ export function runtime(defaults: RequestOpts) {
         ...req,
         ...(body != null && { body: JSON.stringify(body) }),
         headers: {
-          "Content-Type": "application/json",
           ...headers,
+          "Content-Type": hasJsonContentType(String(headers?.["Content-Type"])),
         },
       };
     },
@@ -123,7 +137,7 @@ export function runtime(defaults: RequestOpts) {
         ...(body != null && { body: qs.form(body) }),
         headers: {
           ...headers,
-          "Content-Type": "application/x-www-form-urlencoded",
+          "Content-Type": hasFormContentType(String(headers?.["Content-Type"])),
         },
       };
     },


### PR DESCRIPTION
This Pull Request attempts to allow the `Content-Type` header to be customized.
Here's a little more context about the reason for this proposal: https://github.com/oazapfts/oazapfts/issues/452

Hi @Xiphe 
In our conversation to allow this (https://github.com/oazapfts/oazapfts/issues/452), you commented:
> Gave this another thought. I think just switching out the lines should be treated as a breaking change ...

But I wasn't sure if you were just not convinced about switching these lines. 
I gave some thoughts about how these changes could affect negatively another user but I think it would only be an issue if they have an unnoticed modification of the `Content-Type` header. But of course, I could totally be missing some scenarios.

Please let me know if you think we should go for a more complex approach on this or if you have any other thoughts about this.