### PR TITLE
Add prefixItems to type generation

### DIFF
--- a/src/codegen/__fixtures__/prefixItems.json
+++ b/src/codegen/__fixtures__/prefixItems.json
@@ -1,0 +1,67 @@
+{
+  "info": {
+    "title": "example with prefixItems introduced in OpenAPI 3.1",
+    "version": "0.0.1"
+  },
+  "openapi": "3.1.0",
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/test/": {
+      "get": {
+        "summary": "",
+        "description": "",
+        "operationId": "get_test",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Coordinates"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Coordinates": {
+        "prefixItems": [
+          {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Lon"
+          },
+          {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Lat"
+          }
+        ],
+        "type": "array",
+        "maxItems": 2,
+        "minItems": 2
+      }
+    }
+  }
+}

--- a/src/codegen/__fixtures__/prefixItems.json
+++ b/src/codegen/__fixtures__/prefixItems.json
@@ -39,9 +39,6 @@
             "anyOf": [
               {
                 "type": "number"
-              },
-              {
-                "type": "integer"
               }
             ],
             "title": "Lon"
@@ -50,9 +47,6 @@
             "anyOf": [
               {
                 "type": "number"
-              },
-              {
-                "type": "integer"
               }
             ],
             "title": "Lat"

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -51,6 +51,7 @@ type SchemaObject = OpenAPIV3.SchemaObject & {
   const?: unknown;
   "x-enumNames"?: string[];
   "x-enum-varnames"?: string[];
+  prefixItems?: (OpenAPIV3.ReferenceObject | SchemaObject)[];
 };
 
 /**
@@ -588,18 +589,10 @@ export default class ApiGenerator {
       // items -> array
       return factory.createArrayTypeNode(this.getTypeFromSchema(schema.items));
     }
-    if ("prefixItems" in schema) {
+    if ("prefixItems" in schema && schema.prefixItems) {
       // prefixItems -> typed tuple
-      // Because we are mixing OpenAPI 3.0 and OpenAPI 3.1 types prefixItems can be defined without items
-      // For some reason typescript assumes schema to be NonArraySchemaObject after the above if statement so we cast it back
-      // Also the definition of prefixItems in openapi-types seems to be wrong so we cast again
-      const prefixItems = (schema as unknown as OpenAPIV3.ArraySchemaObject)
-        .prefixItems as unknown as (
-        | OpenAPIV3.SchemaObject
-        | OpenAPIV3.ReferenceObject
-      )[];
       return factory.createTupleTypeNode(
-        prefixItems.map((schema) => this.getTypeFromSchema(schema)),
+        schema.prefixItems.map((schema) => this.getTypeFromSchema(schema)),
       );
     }
     if (schema.properties || schema.additionalProperties) {

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -588,6 +588,20 @@ export default class ApiGenerator {
       // items -> array
       return factory.createArrayTypeNode(this.getTypeFromSchema(schema.items));
     }
+    if ("prefixItems" in schema) {
+      // prefixItems -> typed tuple
+      // Because we are mixing OpenAPI 3.0 and OpenAPI 3.1 types prefixItems can be defined without items
+      // For some reason typescript assumes schema to be NonArraySchemaObject after the above if statement so we cast it back
+      // Also the definition of prefixItems in openapi-types seems to be wrong so we cast again
+      const prefixItems = (schema as unknown as OpenAPIV3.ArraySchemaObject)
+        .prefixItems as unknown as (
+        | OpenAPIV3.SchemaObject
+        | OpenAPIV3.ReferenceObject
+      )[];
+      return factory.createTupleTypeNode(
+        prefixItems.map((schema) => this.getTypeFromSchema(schema)),
+      );
+    }
     if (schema.properties || schema.additionalProperties) {
       // properties -> literal type
       return this.getTypeFromProperties(

--- a/src/codegen/index.test.ts
+++ b/src/codegen/index.test.ts
@@ -86,6 +86,13 @@ describe("generateSource", () => {
     expect(src).toContain("getPetById(id: number, { idQuery }");
   });
 
+  it("should generate correct array type for prefixItems", async () => {
+    const src = await generate("/__fixtures__/prefixItems.json");
+    expect(src).toContain(
+      "export type Coordinates = [ number | number, number | number ];",
+    );
+  });
+
   it("should generate valid identifiers for oneOf with refs", async () => {
     const src = await generate("/__fixtures__/oneOfRef.yaml");
     expect(src).toContain("PathsFilterGetParameters0SchemaOneOf0");

--- a/src/codegen/index.test.ts
+++ b/src/codegen/index.test.ts
@@ -88,9 +88,7 @@ describe("generateSource", () => {
 
   it("should generate correct array type for prefixItems", async () => {
     const src = await generate("/__fixtures__/prefixItems.json");
-    expect(src).toContain(
-      "export type Coordinates = [ number | number, number | number ];",
-    );
+    expect(src).toContain("export type Coordinates = [ number, number ];");
   });
 
   it("should generate valid identifiers for oneOf with refs", async () => {


### PR DESCRIPTION
Closes #461

I simply added another if statement and added the prefixItems to the SchemaObject type.

Also would you like me to add a test?

Are you using prettier or something, mine seems to be on different settings.