### PR TITLE
fix: handler functions' argument type

### DIFF
--- a/demo/api.test.ts
+++ b/demo/api.test.ts
@@ -277,6 +277,17 @@ describe("handle", () => {
     const promise = handle(api.updatePet({ name: "Gizmo", photoUrls: [] }), {});
     await expect(promise).rejects.toHaveProperty("status", 204);
   });
+
+  it("should type response as Pet", async () => {
+    const res = await handle(api.getPetById(1), {
+      200(res) {
+        return res;
+      },
+    });
+
+    ({}) as api.Pet satisfies typeof res;
+    expect(res).toBeDefined();
+  });
 });
 
 describe("okify", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export type ResponseHandler<T extends ApiResponse> = {
   default?: (status: number, data: any) => any;
 };
 
-export type FunctionReturnType<T> = T extends (args: any[]) => any
+export type FunctionReturnType<T> = T extends (...args: any[]) => any
   ? ReturnType<T>
   : never;
 


### PR DESCRIPTION
#### Description
* Fixes the type used to match handler functions inside `handle`, [FunctionReturnType](https://github.com/oazapfts/oazapfts/blob/4fafe0028f0484153c9f458aba5e0fb5e0f4f4ae/src/index.ts#L21-L23), so that it correctly matches handlers with any arguments.
* Add a test to assert the return type of `handle`. This test is non-complete, since technically any type that `api.Pet` can partially satisfy will pass, but it's the best I can come up with since `never` is a subtype to all types.

#### Related issues
- Closes #460 