### PR TITLE
Support discriminator with allOf

### DIFF
--- a/src/codegen/__fixtures__/allOf.json
+++ b/src/codegen/__fixtures__/allOf.json
@@ -40,6 +40,37 @@
           }
         }
       }
+    },
+    "/pet/{pet_id}": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "pet_id",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -74,6 +105,66 @@
             "type": "integer"
           }
         }
+      },
+      "Pet": {
+        "type": "object",
+        "properties": {
+          "petType": {
+            "type": "string"
+          }
+        },
+        "required": ["petType"],
+        "discriminator": {
+          "propertyName": "petType",
+          "mapping": {
+            "dog": "#/components/schemas/Dog"
+          }
+        }
+      },
+      "Cat": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "Dog": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "bark": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "Lizard": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "lovesRocks": {
+                "type": "boolean"
+              }
+            }
+          }
+        ]
       }
     }
   }

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -56,7 +56,7 @@ type SchemaObject = OpenAPIV3.SchemaObject & {
   "x-enumNames"?: string[];
   "x-enum-varnames"?: string[];
   prefixItems?: (OpenAPIV3.ReferenceObject | SchemaObject)[];
-  metadata?: SchemaMetadata; // information oazapfts uses while generating code
+  metadata?: SchemaMetadata; // information added by oazapfts
 };
 
 /**
@@ -288,8 +288,7 @@ export default class ApiGenerator {
     public readonly isConverted = false,
   ) {}
 
-  // Store which schemas are parent schemas.
-  // See `preprocessSchemas` for the definition of a parent schema.
+  // Store parent schemas (see `preprocessSchemas` for the definition of a parent schema)
   parentSchemaRefs: Set<string> = new Set();
 
   aliases: (ts.TypeAliasDeclaration | ts.InterfaceDeclaration)[] = [];
@@ -968,11 +967,10 @@ export default class ApiGenerator {
   /**
    * Does three things:
    * 1. Add a `metadata` property.
-   * 2. Record which schemas are parent schemas in `this.parentSchemaRefs`. The parent schema refers
-   *    to the schema that has a `discriminator` property which is neither used in conjunction with
-   *    `oneOf` nor `anyOf`.
-   * 3. Make all mappings of parent schemas explicit in order to generate types of parent schemas on
-   *    the spot.
+   * 2. Record parent schemas in `this.parentSchemaRefs`. A parent schema refers to a schema that
+   *    has a `discriminator` property which is neither used in conjunction with `oneOf` nor
+   *    `anyOf`.
+   * 3. Make all mappings of parent schemas explicit to generate types immediately.
    */
   preprocessSchemas(schemas: {
     [key: string]: OpenAPIV3.ReferenceObject | SchemaObject;

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -137,7 +137,7 @@ function getRefBasename(ref: string) {
 
 /**
  * Returns a name for the given ref that can be used as basis for a type
- * alias. This usually is the baseName, unless the ref ends with a number,
+ * alias. This usually is the baseName, unless the ref starts with a number,
  * in which case the whole ref is returned, with slashes turned into
  * underscores.
  */

--- a/src/codegen/index.test.ts
+++ b/src/codegen/index.test.ts
@@ -57,6 +57,18 @@ describe("generateSource", () => {
     );
   });
 
+  it("should support discriminator used in conjunction with allOf", async () => {
+    const src = await generate("/__fixtures__/allOf.json");
+    expect(src).toContain("export type PetBase = { petType: string; };");
+    expect(src).toContain("export type Pet = Dog | Cat | Lizard;");
+    expect(src).toContain(
+      'export type Dog = { petType: "dog"; } & PetBase & { bark?: string; };',
+    );
+    expect(src).toContain(
+      'export type Lizard = { petType: "Lizard"; } & PetBase & { lovesRocks?: boolean; };',
+    );
+  });
+
   it("should handle application/geo+json", async () => {
     const src = await generate("/__fixtures__/geojson.json");
     expect(src).toContain(


### PR DESCRIPTION
Closes #422 

This PR adds support for the discriminator used in conjunction with `allOf` constructor. See the added tests for an example. Several key concepts are introduced in this PR:

1. `metadata` property: A new property called `metadata` has been added to the `SchemaObject`. This property contains information added by oazapft. As of now, only the `selfRef` is present in the `SchemaMetadata` type, but other properties may be added in the future.
2. parent schema: The term "parent schema" appears in several places. In this context, it refers to a schema that has a `discriminator` property which is neither used in conjunction with `oneOf` nor `anyOf`. This is also described in the comment of `preprocessSchemas`.
3. `ignoreDiscriminator` parameter: In order to support the discriminator used with `allOf`, it's important to determine whether a reference to a parent schema is pointing to the parent schema itself or the union of its alternative (child) schemas. The type alias for a parent schema itself can be obtained by passing `true` to the `ignoreDiscriminator`, which is a newly added parameter in `getRefAlias`.