### PR TITLE
Prevent infinite recursion of checkSchemaOnlyMode

### DIFF
--- a/src/codegen/__fixtures__/recursive.yaml
+++ b/src/codegen/__fixtures__/recursive.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+info:
+  title: Recursive API
+  version: 1.0.0
+paths:
+  /api/some-folder:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FolderDto'
+components:
+  schemas:
+    FolderDto:
+      type: object
+      properties:
+        name:
+          type: string
+        files:
+          type: array
+          items:
+            type: string
+        folders:
+          type: array
+          items:
+            $ref: '#/components/schemas/FolderDto'

--- a/src/codegen/index.test.ts
+++ b/src/codegen/index.test.ts
@@ -69,6 +69,13 @@ describe("generateSource", () => {
     );
   });
 
+  it("should support recursive schemas", async () => {
+    const src = await generate("/__fixtures__/recursive.yaml");
+    expect(src).toContain(
+      "export type FolderDto = { name?: string; files?: string[]; folders?: FolderDto[]; };",
+    );
+  });
+
   it("should handle application/geo+json", async () => {
     const src = await generate("/__fixtures__/geojson.json");
     expect(src).toContain(


### PR DESCRIPTION
Closes #486 

In the current implementation, `checkSchemaOnlyMode` does not work for recursive schemas (i.e. encounter inifinite recursion). This PR addresses the problem.