### PR TITLE
[Enhancement] Improve oneOf schema handling

### DIFF
--- a/src/codegen/__fixtures__/oneOfMerge.yaml
+++ b/src/codegen/__fixtures__/oneOfMerge.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.3
+info:
+  title: OneOfMerge
+  version: 0.1.0
+paths:
+  /mix:
+    get:
+      description: stats
+      parameters:
+        - name: param1
+          in: query
+          schema:
+            oneOf:
+            - required:
+              - c
+              properties:
+                a:
+                  type: string
+            - required:
+              - b
+              properties:
+                b:
+                  type: string
+            required:
+            - d
+            properties:
+              c:
+                type: string
+              d:
+                enum:
+                - enum1
+                - enum2
+                type: string
+      responses:
+        "200":
+          description: ok

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -5,6 +5,7 @@ import { OpenAPIV3 } from "openapi-types";
 import * as cg from "./tscodegen";
 import generateServers, { defaultBaseUrl } from "./generateServers";
 import { Opts } from ".";
+import merge from "deepmerge";
 
 export const verbs = [
   "GET",
@@ -570,8 +571,14 @@ export default class ApiGenerator {
     }
 
     if (schema.oneOf) {
+      const clone = { ...schema };
+      delete clone.oneOf;
       // oneOf -> union
-      return this.getUnionType(schema.oneOf, schema.discriminator, onlyMode);
+      return this.getUnionType(
+        schema.oneOf.map((variant) => merge(variant as any, clone as any)),
+        schema.discriminator,
+        onlyMode,
+      );
     }
     if (schema.anyOf) {
       // anyOf -> union

--- a/src/codegen/index.test.ts
+++ b/src/codegen/index.test.ts
@@ -108,6 +108,13 @@ describe("generateSource", () => {
     expect(src).toContain("PathsFilterGetParameters0SchemaOneOf0");
   });
 
+  it("should merge properties within oneOf schema variations", async () => {
+    const src = await generate("/__fixtures__/oneOfMerge.yaml");
+    expect(src).toContain(
+      '{ param1?: { a?: string; c: string; d: "enum1" | "enum2"; } | { b: string; c?: string; d: "enum1" | "enum2"; }'
+    );
+  });
+
   it("should support parameters specified with content", async () => {
     const src = await generate("/__fixtures__/contentParams.json");
     expect(src).toContain(


### PR DESCRIPTION
This commit introduces an enhancement to better handle the oneOf schema in OpenAPI definitions.

- Added a new OpenAPI test fixture - oneOfMerge.yaml
- Updated logic in the codegen script where oneOf schemas are encountered. The properties of the schema are now deeply merged to accommodate different variations.
- Added a new test case to confirm the improved handling of oneOf schemas.

## OpenAPI

```yaml
openapi: 3.0.3
info:
  title: OneOfMerge
  version: 0.1.0
paths:
  /mix:
    get:
      description: stats
      parameters:
        - name: param1
          in: query
          schema:
            oneOf:
            - required:
              - c
              properties:
                a:
                  type: string
            - required:
              - b
              properties:
                b:
                  type: string
            required:
            - d
            properties:
              c:
                type: string
              d:
                enum:
                - enum1
                - enum2
                type: string
      responses:
        "200":
          description: ok
```

## Before

```ts
/** * OneOfMerge * 0.1.0 * DO NOT MODIFY - This file has been generated using oazapfts. * See https://www.npmjs.com/package/oazapfts */ import * as Oazapfts
  from 'oazapfts/lib/runtime';
import * as QS from 'oazapfts/lib/runtime/query';
export const defaults: Oazapfts.RequestOpts = {baseUrl: '/'};
const oazapfts = Oazapfts.runtime (defaults);
export const servers = {};
/** * stats */ export function getMix (
  {param1}: {param1?: {a?: string} | {b: string}} = {},
  opts?: Oazapfts.RequestOpts
) {
  return oazapfts.fetchText (`/mix${QS.query (QS.explode ({param1}))}`, {
    ...opts,
  });
}
```

## After

```ts
/** * OneOfMerge * 0.1.0 * DO NOT MODIFY - This file has been generated using oazapfts. * See https://www.npmjs.com/package/oazapfts */ import * as Oazapfts from "oazapfts/lib/runtime";
import * as QS from "oazapfts/lib/runtime/query";
export const defaults: Oazapfts.RequestOpts = { baseUrl: "/" };
const oazapfts = Oazapfts.runtime(defaults);
export const servers = {};
/** * stats */ export function getMix(
  {
    param1,
  }: {
    param1?:
      | { a?: string; c: string; d: "enum1" | "enum2" }
      | { b: string; c?: string; d: "enum1" | "enum2" };
  } = {},
  opts?: Oazapfts.RequestOpts
) {
  return oazapfts.fetchText(`/mix${QS.query(QS.explode({ param1 }))}`, {
    ...opts,
  });
}
```