### PR TITLE
Let Fetch API set the Content-Type header

### DIFF
--- a/demo/api.test.ts
+++ b/demo/api.test.ts
@@ -387,10 +387,7 @@ describe("multipart", () => {
       "http://localhost:8000/v2/pet/5/uploadImage",
       expect.objectContaining({
         body: expect.any(FormData),
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "multipart/form-data",
-        },
+        headers: { Accept: "application/json" },
         method: "POST",
       }),
     );

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -114,12 +114,6 @@ export function runtime(defaults: RequestOpts) {
       : "application/x-www-form-urlencoded";
   }
 
-  function ensureMultipartContentType(contentTypeHeader: string) {
-    return contentTypeHeader?.startsWith("multipart/form-data")
-      ? contentTypeHeader
-      : "multipart/form-data";
-  }
-
   return {
     ok,
     fetchText,
@@ -177,15 +171,14 @@ export function runtime(defaults: RequestOpts) {
         }
       });
 
+      // Remove the Content-Type header because it should be automatically set
+      // by the Fetch API.
+      delete headers?.["Content-Type"];
+
       return {
         ...req,
         body: data,
-        headers: {
-          ...headers,
-          "Content-Type": ensureMultipartContentType(
-            String(headers?.["Content-Type"]),
-          ),
-        },
+        headers,
       };
     },
   };


### PR DESCRIPTION
Closes #512 

This RP has removed the Content-Type header from multipart/form-data requests. This is because the Content-Type header should be automatically set by the Fetch API.