### PR TITLE
Smarter header defaults and handling

### DIFF
--- a/demo/api.test.ts
+++ b/demo/api.test.ts
@@ -387,13 +387,12 @@ describe("multipart", () => {
       "http://localhost:8000/v2/pet/5/uploadImage",
       expect.objectContaining({
         body: expect.any(FormData),
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "multipart/form-data",
-        },
         method: "POST",
       }),
     );
+    expect(Object.fromEntries(customFetch.mock.calls[0][1].headers)).toEqual({
+      accept: "application/json",
+    });
     const formData = customFetch.mock.calls[0][1].body as FormData;
     expect(formData.getAll("files").length).toBe(10);
     const meta = formData.getAll("imageMeta") as Blob[];

--- a/demo/api.ts
+++ b/demo/api.ts
@@ -266,10 +266,9 @@ export function deletePet(
   return oazapfts.fetchText(`/pet/${encodeURIComponent(petId)}`, {
     ...opts,
     method: "DELETE",
-    headers: {
-      ...(opts && opts.headers),
+    headers: oazapfts.mergeHeaders(opts?.headers, {
       api_key: apiKey,
-    },
+    }),
   });
 }
 /**
@@ -321,10 +320,9 @@ export function customizePet(
     {
       ...opts,
       method: "POST",
-      headers: {
-        ...(opts && opts.headers),
+      headers: oazapfts.mergeHeaders(opts?.headers, {
         "x-color-options": xColorOptions,
-      },
+      }),
     },
   );
 }

--- a/demo/enumApi.ts
+++ b/demo/enumApi.ts
@@ -265,10 +265,9 @@ export function deletePet(
   return oazapfts.fetchText(`/pet/${encodeURIComponent(petId)}`, {
     ...opts,
     method: "DELETE",
-    headers: {
-      ...(opts && opts.headers),
+    headers: oazapfts.mergeHeaders(opts?.headers, {
       api_key: apiKey,
-    },
+    }),
   });
 }
 /**
@@ -320,10 +319,9 @@ export function customizePet(
     {
       ...opts,
       method: "POST",
-      headers: {
-        ...(opts && opts.headers),
+      headers: oazapfts.mergeHeaders(opts?.headers, {
         "x-color-options": xColorOptions,
-      },
+      }),
     },
   );
 }

--- a/demo/mergedReadWriteApi.ts
+++ b/demo/mergedReadWriteApi.ts
@@ -239,10 +239,9 @@ export function deletePet(
   return oazapfts.fetchText(`/pet/${encodeURIComponent(petId)}`, {
     ...opts,
     method: "DELETE",
-    headers: {
-      ...(opts && opts.headers),
+    headers: oazapfts.mergeHeaders(opts?.headers, {
       api_key: apiKey,
-    },
+    }),
   });
 }
 /**
@@ -294,10 +293,9 @@ export function customizePet(
     {
       ...opts,
       method: "POST",
-      headers: {
-        ...(opts && opts.headers),
+      headers: oazapfts.mergeHeaders(opts?.headers, {
         "x-color-options": xColorOptions,
-      },
+      }),
     },
   );
 }

--- a/demo/optimisticApi.ts
+++ b/demo/optimisticApi.ts
@@ -279,10 +279,9 @@ export function deletePet(
     oazapfts.fetchText(`/pet/${encodeURIComponent(petId)}`, {
       ...opts,
       method: "DELETE",
-      headers: {
-        ...(opts && opts.headers),
+      headers: oazapfts.mergeHeaders(opts?.headers, {
         api_key: apiKey,
-      },
+      }),
     }),
   );
 }
@@ -338,10 +337,9 @@ export function customizePet(
       {
         ...opts,
         method: "POST",
-        headers: {
-          ...(opts && opts.headers),
+        headers: oazapfts.mergeHeaders(opts?.headers, {
           "x-color-options": xColorOptions,
-        },
+        }),
       },
     ),
   );

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -1312,26 +1312,24 @@ export default class ApiGenerator {
           init.push(
             factory.createPropertyAssignment(
               "headers",
-              factory.createObjectLiteralExpression(
-                [
-                  factory.createSpreadAssignment(
-                    factory.createLogicalAnd(
-                      factory.createIdentifier("opts"),
-                      factory.createPropertyAccessExpression(
-                        factory.createIdentifier("opts"),
-                        "headers",
+              callOazapftsFunction("mergeHeaders", [
+                factory.createPropertyAccessChain(
+                  factory.createIdentifier("opts"),
+                  factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                  "headers",
+                ),
+                factory.createObjectLiteralExpression(
+                  [
+                    ...header.map((param) =>
+                      cg.createPropertyAssignment(
+                        param.name,
+                        factory.createIdentifier(getArgName(param)),
                       ),
                     ),
-                  ),
-                  ...header.map((param) =>
-                    cg.createPropertyAssignment(
-                      param.name,
-                      factory.createIdentifier(getArgName(param)),
-                    ),
-                  ),
-                ],
-                true,
-              ),
+                  ],
+                  true,
+                ),
+              ]),
             ),
           );
         }

--- a/src/runtime/headers.ts
+++ b/src/runtime/headers.ts
@@ -1,0 +1,37 @@
+export type CustomHeaders = Record<
+  string,
+  string | null | boolean | number | undefined
+>;
+
+export function mergeHeaders(
+  base: HeadersInit | CustomHeaders | undefined,
+  overwrite?: HeadersInit | CustomHeaders,
+) {
+  const baseHeaders = normalizeHeaders(base);
+  const overwriteHeaders = normalizeHeaders(overwrite);
+
+  overwriteHeaders.forEach((value, key) => {
+    baseHeaders.set(key, value);
+  });
+
+  return baseHeaders;
+}
+
+export function normalizeHeaders(
+  headers: HeadersInit | CustomHeaders | undefined,
+) {
+  // This might be custom header config containing null | boolean | number | undefined
+  // By default Headers constructor will convert them to string but we don't want that
+  // for nullish values.
+  if (headers && !(headers instanceof Headers) && !Array.isArray(headers)) {
+    return new Headers(
+      Object.fromEntries(
+        Object.entries(headers)
+          .filter(([, v]) => v != null)
+          .map(([k, v]) => [k, String(v)]),
+      ),
+    );
+  }
+
+  return new Headers(headers);
+}

--- a/src/runtime/util.ts
+++ b/src/runtime/util.ts
@@ -45,13 +45,6 @@ export function delimited(delimiter = ",") {
       .join("&");
 }
 
-/**
- * Deeply remove all properties with undefined values.
- */
-export function stripUndefined<T>(obj: T) {
-  return obj && JSON.parse(JSON.stringify(obj));
-}
-
 export function joinUrl(...parts: Array<string | undefined>) {
   return parts
     .filter(Boolean)


### PR DESCRIPTION
- stop setting Content-Type header for multipart requests
- support HeaderInit in request objects
- support default headers

BREAKING CHANGE:
multipart/form-data headers are not set by oazapfts anymore as these are usually automatically set by the browser/node when this causes problems on your end you can set Content-Type=multipart/form-data manually via RequestOpts

oazapfts runtime now works with `Header` instead of plain Objects `{}`. This might affect you when you use a custom fetch implementation and manipulate headers there

oazapfts no longer safe-guards "Content-Type" headers
in the past we discarded custom Content-Type headers that didn't start with `json` for json requests
and similarly Content-Type headers that didn't start with application/x-www-form-urlencoded for form requests
we now trust you to set the correct headers for your requests

--

fix https://github.com/oazapfts/oazapfts/issues/512
ref https://github.com/oazapfts/oazapfts/issues/509