### PR TITLE
feat: Include property descriptions

### DIFF
--- a/demo/api.ts
+++ b/demo/api.ts
@@ -28,9 +28,13 @@ export type Pet = {
   name: string;
   photoUrls: string[];
   tags?: Tag[];
+  /** pet status in the store */
   status?: "available" | "pending" | "sold" | "private" | "10percent";
+  /** Always true for a pet */
   animal?: true;
+  /** Size scale for pets */
   size?: "P" | "M" | "G" | "0";
+  /** integer test case for #349 */
   typeId?: 1 | 2 | 3 | 4 | 6 | 8;
 };
 export type ApiResponse = {
@@ -43,6 +47,7 @@ export type Order = {
   petId?: number;
   quantity?: number;
   shipDate?: string;
+  /** Order Status */
   status?: "placed" | "approved" | "delivered";
   complete?: boolean;
 };
@@ -54,7 +59,9 @@ export type User = {
   email?: string;
   password?: string;
   phone?: string;
+  /** User Status */
   userStatus?: number;
+  /** user category in the store */
   category?: "rich" | "wealthy" | "poor";
 };
 export type Schema = string;
@@ -237,7 +244,9 @@ export function getPetById(petId: number, opts?: Oazapfts.RequestOpts) {
 export function updatePetWithForm(
   petId: number,
   body?: {
+    /** Updated name of the pet */
     name?: string;
+    /** Updated status of the pet */
     status?: string;
   },
   opts?: Oazapfts.RequestOpts,
@@ -282,6 +291,7 @@ export function uploadFiles(
       name: string;
       description?: string;
     }[];
+    /** files to upload */
     files: Blob[];
   },
   opts?: Oazapfts.RequestOpts,

--- a/demo/enumApi.ts
+++ b/demo/enumApi.ts
@@ -28,9 +28,13 @@ export type Pet = {
   name: string;
   photoUrls: string[];
   tags?: Tag[];
+  /** pet status in the store */
   status?: Status;
+  /** Always true for a pet */
   animal?: true;
+  /** Size scale for pets */
   size?: Size;
+  /** integer test case for #349 */
   typeId?: TypeId;
 };
 export type ApiResponse = {
@@ -43,6 +47,7 @@ export type Order = {
   petId?: number;
   quantity?: number;
   shipDate?: string;
+  /** Order Status */
   status?: Status2;
   complete?: boolean;
 };
@@ -54,7 +59,9 @@ export type User = {
   email?: string;
   password?: string;
   phone?: string;
+  /** User Status */
   userStatus?: number;
+  /** user category in the store */
   category?: Category2;
 };
 export type Schema = string;
@@ -236,7 +243,9 @@ export function getPetById(petId: number, opts?: Oazapfts.RequestOpts) {
 export function updatePetWithForm(
   petId: number,
   body?: {
+    /** Updated name of the pet */
     name?: string;
+    /** Updated status of the pet */
     status?: string;
   },
   opts?: Oazapfts.RequestOpts,
@@ -281,6 +290,7 @@ export function uploadFiles(
       name: string;
       description?: string;
     }[];
+    /** files to upload */
     files: Blob[];
   },
   opts?: Oazapfts.RequestOpts,

--- a/demo/mergedReadWriteApi.ts
+++ b/demo/mergedReadWriteApi.ts
@@ -28,9 +28,13 @@ export type Pet = {
   name: string;
   photoUrls: string[];
   tags?: Tag[];
+  /** pet status in the store */
   status?: "available" | "pending" | "sold" | "private" | "10percent";
+  /** Always true for a pet */
   animal?: true;
+  /** Size scale for pets */
   size?: "P" | "M" | "G" | "0";
+  /** integer test case for #349 */
   typeId?: 1 | 2 | 3 | 4 | 6 | 8;
 };
 export type ApiResponse = {
@@ -43,6 +47,7 @@ export type Order = {
   petId?: number;
   quantity?: number;
   shipDate?: string;
+  /** Order Status */
   status?: "placed" | "approved" | "delivered";
   complete?: boolean;
 };
@@ -54,7 +59,9 @@ export type User = {
   email?: string;
   password?: string;
   phone?: string;
+  /** User Status */
   userStatus?: number;
+  /** user category in the store */
   category?: "rich" | "wealthy" | "poor";
 };
 export type Schema = string;
@@ -210,7 +217,9 @@ export function getPetById(petId: number, opts?: Oazapfts.RequestOpts) {
 export function updatePetWithForm(
   petId: number,
   body?: {
+    /** Updated name of the pet */
     name?: string;
+    /** Updated status of the pet */
     status?: string;
   },
   opts?: Oazapfts.RequestOpts,
@@ -255,6 +264,7 @@ export function uploadFiles(
       name: string;
       description?: string;
     }[];
+    /** files to upload */
     files: Blob[];
   },
   opts?: Oazapfts.RequestOpts,

--- a/demo/optimisticApi.ts
+++ b/demo/optimisticApi.ts
@@ -28,9 +28,13 @@ export type Pet = {
   name: string;
   photoUrls: string[];
   tags?: Tag[];
+  /** pet status in the store */
   status?: "available" | "pending" | "sold" | "private" | "10percent";
+  /** Always true for a pet */
   animal?: true;
+  /** Size scale for pets */
   size?: "P" | "M" | "G" | "0";
+  /** integer test case for #349 */
   typeId?: 1 | 2 | 3 | 4 | 6 | 8;
 };
 export type ApiResponse = {
@@ -43,6 +47,7 @@ export type Order = {
   petId?: number;
   quantity?: number;
   shipDate?: string;
+  /** Order Status */
   status?: "placed" | "approved" | "delivered";
   complete?: boolean;
 };
@@ -54,7 +59,9 @@ export type User = {
   email?: string;
   password?: string;
   phone?: string;
+  /** User Status */
   userStatus?: number;
+  /** user category in the store */
   category?: "rich" | "wealthy" | "poor";
 };
 export type Schema = string;
@@ -247,7 +254,9 @@ export function getPetById(petId: number, opts?: Oazapfts.RequestOpts) {
 export function updatePetWithForm(
   petId: number,
   body?: {
+    /** Updated name of the pet */
     name?: string;
+    /** Updated status of the pet */
     status?: string;
   },
   opts?: Oazapfts.RequestOpts,
@@ -296,6 +305,7 @@ export function uploadFiles(
       name: string;
       description?: string;
     }[];
+    /** files to upload */
     files: Blob[];
   },
   opts?: Oazapfts.RequestOpts,

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -895,11 +895,24 @@ export default class ApiGenerator {
       if (!isRequired && this.opts.unionUndefined) {
         type = factory.createUnionTypeNode([type, cg.keywordType.undefined]);
       }
-      return cg.createPropertySignature({
+
+      const signature = cg.createPropertySignature({
         questionToken: !isRequired,
         name,
         type,
       });
+
+      if ("description" in schema && schema.description) {
+        ts.addSyntheticLeadingComment(
+          signature,
+          ts.SyntaxKind.MultiLineCommentTrivia,
+          // Ensures it is formatted like a JSDoc comment: /** description here */
+          `* ${schema.description} `,
+          true,
+        );
+      }
+
+      return signature;
     });
     if (additionalProperties) {
       const type =


### PR DESCRIPTION
This emits `SchemaObject.description` in a multi-line comment in front of the property.

This makes sure useful documentation is included in the generated code.