### PR TITLE
Escape any comment closing tags in schema descriptions

### DIFF
--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -903,11 +903,14 @@ export default class ApiGenerator {
       });
 
       if ("description" in schema && schema.description) {
+        // Escape any JSDoc comment closing tags in description
+        const description = schema.description.replace("*/", "*\\/");
+
         ts.addSyntheticLeadingComment(
           signature,
           ts.SyntaxKind.MultiLineCommentTrivia,
           // Ensures it is formatted like a JSDoc comment: /** description here */
-          `* ${schema.description} `,
+          `* ${description} `,
           true,
         );
       }


### PR DESCRIPTION
Fixes https://github.com/oazapfts/oazapfts/issues/545.

Before:

```ts
/** The URL of the configuration page for the time tracking provider app. For example, */example/config/url*. This property is only returned if the `adminPageKey` property is set in the module descriptor of the time tracking provider app. */
url?: string;
```

After:

```ts
/** The URL of the configuration page for the time tracking provider app. For example, *\/example/config/url*. This property is only returned if the `adminPageKey` property is set in the module descriptor of the time tracking provider app. */
url?: string;
```