### PR TITLE
feat: add --argumentStyle option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Options:
 --optimistic
 --useEnumType
 --mergeReadWriteOnly
+--argumentStyle=<positional | object> (default: positional)
 ```
 
 Where `<spec>` is the URL or local path of an OpenAPI or Swagger spec (in either json or yml) and `<filename>` is the location of the `.ts` file to be generated. If the filename is omitted, the code is written to stdout.
@@ -47,6 +48,8 @@ Where `<spec>` is the URL or local path of an OpenAPI or Swagger spec (in either
 - `--useEnumType` generate enums instead of union types
 
 - `--mergeReadWriteOnly` by default oazapfs will generate separate types for read-only and write-only properties. This option will merge them into one type.
+
+- `--argumentStyle` if "object" generated functions take single object style argument for parameters and requestBody, by default it's "positional" and parameters are separate as positional arguments
 
 ## Consuming the generated API
 

--- a/demo/objectStyleArgument.ts
+++ b/demo/objectStyleArgument.ts
@@ -1,0 +1,831 @@
+/**
+ * Swagger Petstore
+ * 1.0.0
+ * DO NOT MODIFY - This file has been generated using oazapfts.
+ * See https://www.npmjs.com/package/oazapfts
+ */
+import * as Oazapfts from "oazapfts/lib/runtime";
+import * as QS from "oazapfts/lib/runtime/query";
+export const defaults: Oazapfts.RequestOpts = {
+  baseUrl: "https://petstore.swagger.io/v2",
+};
+const oazapfts = Oazapfts.runtime(defaults);
+export const servers = {
+  server1: "https://petstore.swagger.io/v2",
+  server2: "http://petstore.swagger.io/v2",
+};
+export type Category = {
+  id?: number;
+  name?: string;
+};
+export type Tag = {
+  id?: number;
+  name?: string;
+};
+export type Pet = {
+  id?: number;
+  category?: Category;
+  name: string;
+  photoUrls: string[];
+  tags?: Tag[];
+  /** pet status in the store */
+  status?: "available" | "pending" | "sold" | "private" | "10percent";
+  /** Always true for a pet */
+  animal?: true;
+  /** Size scale for pets */
+  size?: "P" | "M" | "G" | "0";
+  /** integer test case for #349 */
+  typeId?: 1 | 2 | 3 | 4 | 6 | 8;
+};
+export type ApiResponse = {
+  code?: number;
+  type?: string;
+  message?: string;
+};
+export type Order = {
+  id?: number;
+  petId?: number;
+  quantity?: number;
+  shipDate?: string;
+  /** Order Status */
+  status?: "placed" | "approved" | "delivered";
+  complete?: boolean;
+};
+export type User = {
+  id?: number;
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  password?: string;
+  phone?: string;
+  /** User Status */
+  userStatus?: number;
+  /** user category in the store */
+  category?: "rich" | "wealthy" | "poor";
+};
+export type Schema = string;
+export type Schema2 = number;
+export type Option = ("one" | "two" | "three")[];
+export type EnumToRef = "monkey" | "dog" | "cat";
+export type Product = {
+  name: string;
+  description: string;
+  currency: string;
+};
+export type ProductRead = {
+  id: string;
+  name: string;
+  description: string;
+  currency: string;
+  producerID: string;
+};
+export type ProductWrite = {
+  name: string;
+  description: string;
+  hidden?: boolean;
+  currency: string;
+};
+export type PagedListOfProduct = {
+  items: Product[];
+  totalPages: number;
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+};
+export type PagedListOfProductRead = {
+  items: ProductRead[];
+  totalPages: number;
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+};
+export type PagedListOfProductWrite = {
+  items: ProductWrite[];
+  totalPages: number;
+  pageIndex: number;
+  pageSize: number;
+  totalCount: number;
+};
+export type ReadWriteMixed = {};
+export type ReadWriteMixedRead = {
+  message: string;
+};
+export type ReadWriteMixedWrite = {
+  email: string;
+  password: string;
+};
+/**
+ * Update an existing pet
+ */
+export function updatePet(
+  {
+    pet,
+  }: {
+    pet: Pet;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 204;
+        data: string;
+      }
+    | {
+        status: 404;
+        data: string;
+      }
+    | {
+        status: number;
+        data: {
+          errors?: string[];
+        };
+      }
+  >(
+    "/pet",
+    oazapfts.json({
+      ...opts,
+      method: "PUT",
+      body: pet,
+    }),
+  );
+}
+/**
+ * Add a new pet to the store
+ */
+export function addPet(
+  {
+    pet,
+  }: {
+    pet: Pet;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: Pet;
+      }
+    | {
+        status: 201;
+        data: {
+          id?: string;
+        };
+      }
+  >(
+    "/pet",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: pet,
+    }),
+  );
+}
+/**
+ * Finds Pets by status
+ */
+export function findPetsByStatus(
+  {
+    status,
+  }: {
+    status: ("available" | "pending" | "sold")[];
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: Pet[];
+      }
+    | {
+        status: 400;
+        data: string;
+      }
+  >(
+    `/pet/findByStatus${QS.query(
+      QS.explode({
+        status,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * Finds Pets by tags
+ */
+export function findPetsByTags(
+  {
+    tags,
+  }: {
+    tags: string[];
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: Pet[];
+      }
+    | {
+        status: 400;
+        data: string;
+      }
+  >(
+    `/pet/findByTags${QS.query(
+      QS.explode({
+        tags,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * Find pet by ID
+ */
+export function getPetById(
+  {
+    petId,
+  }: {
+    petId: number;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: Pet;
+      }
+    | {
+        status: 400;
+        data: string;
+      }
+    | {
+        status: 404;
+      }
+  >(`/pet/${encodeURIComponent(petId)}`, {
+    ...opts,
+  });
+}
+/**
+ * Updates a pet in the store with form data
+ */
+export function updatePetWithForm(
+  {
+    petId,
+    body,
+  }: {
+    petId: number;
+    body?: {
+      /** Updated name of the pet */
+      name?: string;
+      /** Updated status of the pet */
+      status?: string;
+    };
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    `/pet/${encodeURIComponent(petId)}`,
+    oazapfts.form({
+      ...opts,
+      method: "POST",
+      body,
+    }),
+  );
+}
+/**
+ * Deletes a pet
+ */
+export function deletePet(
+  {
+    apiKey,
+    petId,
+  }: {
+    apiKey?: string;
+    petId: number;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(`/pet/${encodeURIComponent(petId)}`, {
+    ...opts,
+    method: "DELETE",
+    headers: {
+      ...(opts && opts.headers),
+      api_key: apiKey,
+    },
+  });
+}
+/**
+ * uploads an image
+ */
+export function uploadFiles(
+  {
+    petId,
+    body,
+  }: {
+    petId: number;
+    body: {
+      imageMeta: {
+        name: string;
+        description?: string;
+      }[];
+      /** files to upload */
+      files: Blob[];
+    };
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: ApiResponse;
+  }>(
+    `/pet/${encodeURIComponent(petId)}/uploadImage`,
+    oazapfts.multipart({
+      ...opts,
+      method: "POST",
+      body,
+    }),
+  );
+}
+export function customizePet(
+  {
+    petId,
+    furColor,
+    color,
+    xColorOptions,
+  }: {
+    petId: number;
+    furColor?: string;
+    color?: string;
+    xColorOptions?: boolean;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    `/pet/${encodeURIComponent(petId)}/customize${QS.query(
+      QS.explode({
+        "fur.color": furColor,
+        color,
+      }),
+    )}`,
+    {
+      ...opts,
+      method: "POST",
+      headers: {
+        ...(opts && opts.headers),
+        "x-color-options": xColorOptions,
+      },
+    },
+  );
+}
+/**
+ * Returns pet inventories by status
+ */
+export function getInventory(opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: {
+      [key: string]: number;
+    };
+  }>("/store/inventory", {
+    ...opts,
+  });
+}
+/**
+ * Place an order for a pet
+ */
+export function placeOrder(
+  {
+    order,
+  }: {
+    order: Order;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: Order;
+      }
+    | {
+        status: 400;
+        data: string;
+      }
+  >(
+    "/store/order",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: order,
+    }),
+  );
+}
+/**
+ * Find purchase order by ID
+ */
+export function getOrderById(
+  {
+    orderId,
+  }: {
+    orderId: number;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: Order;
+      }
+    | {
+        status: 400;
+        data: string;
+      }
+    | {
+        status: 404;
+        data: string;
+      }
+  >(`/store/order/${encodeURIComponent(orderId)}`, {
+    ...opts,
+  });
+}
+/**
+ * Delete purchase order by ID
+ */
+export function deleteOrder(
+  {
+    orderId,
+  }: {
+    orderId: number;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(`/store/order/${encodeURIComponent(orderId)}`, {
+    ...opts,
+    method: "DELETE",
+  });
+}
+/**
+ * Create user
+ */
+export function createUser(
+  {
+    user,
+  }: {
+    user: User;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    "/user",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: user,
+    }),
+  );
+}
+/**
+ * Creates list of users with given input array
+ */
+export function createUsersWithArrayInput(
+  {
+    body,
+  }: {
+    body: User[];
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    "/user/createWithArray",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body,
+    }),
+  );
+}
+/**
+ * Creates list of users with given input array
+ */
+export function createUsersWithListInput(
+  {
+    body,
+  }: {
+    body: User[];
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    "/user/createWithList",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body,
+    }),
+  );
+}
+/**
+ * Logs user into the system
+ */
+export function loginUser(
+  {
+    username,
+    password,
+  }: {
+    username: string;
+    password: string;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: string;
+      }
+    | {
+        status: 400;
+        data: string;
+      }
+  >(
+    `/user/login${QS.query(
+      QS.explode({
+        username,
+        password,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * Logs out current logged in user session
+ */
+export function logoutUser(opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchText("/user/logout", {
+    ...opts,
+  });
+}
+/**
+ * Get user by user name
+ */
+export function getUserByName(
+  {
+    username,
+  }: {
+    username: string;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: User;
+      }
+    | {
+        status: 400;
+        data: string;
+      }
+    | {
+        status: 404;
+        data: string;
+      }
+  >(`/user/${encodeURIComponent(username)}`, {
+    ...opts,
+  });
+}
+/**
+ * Updated user
+ */
+export function updateUser(
+  {
+    username,
+    user,
+  }: {
+    username: string;
+    user: User;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    `/user/${encodeURIComponent(username)}`,
+    oazapfts.json({
+      ...opts,
+      method: "PUT",
+      body: user,
+    }),
+  );
+}
+/**
+ * Delete user
+ */
+export function deleteUser(
+  {
+    username,
+  }: {
+    username: string;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(`/user/${encodeURIComponent(username)}`, {
+    ...opts,
+    method: "DELETE",
+  });
+}
+export function getIssue31ByFoo(
+  {
+    foo,
+    bar,
+    baz,
+    boo,
+  }: {
+    foo: string;
+    bar?: Schema;
+    baz?: number;
+    boo?: Schema2;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    `/issue31/${encodeURIComponent(foo)}${QS.query(
+      QS.explode({
+        bar,
+        baz,
+        boo,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+export function getObjectParameters(
+  {
+    defaultArray,
+    explodedFormArray,
+    commaArray,
+    defaultSpaceDelimited,
+    explodedSpaceDelimited,
+    spaceDelimited,
+    defaultPipeDelimited,
+    explodedPipeDelimited,
+    pipeDelimited,
+    defaultObject,
+    explodedFormObject,
+    commaObject,
+    deepObject,
+  }: {
+    defaultArray?: Option;
+    explodedFormArray?: Option;
+    commaArray?: Option;
+    defaultSpaceDelimited?: Option;
+    explodedSpaceDelimited?: Option;
+    spaceDelimited?: Option;
+    defaultPipeDelimited?: Option;
+    explodedPipeDelimited?: Option;
+    pipeDelimited?: Option;
+    defaultObject?: Tag;
+    explodedFormObject?: Tag;
+    commaObject?: Tag;
+    deepObject?: Tag;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    `/object-parameters${QS.query(
+      QS.explode({
+        defaultArray,
+        explodedFormArray,
+        defaultSpaceDelimited,
+        explodedSpaceDelimited,
+        defaultPipeDelimited,
+        explodedPipeDelimited,
+        defaultObject,
+        explodedFormObject,
+      }),
+      QS.form({
+        commaArray,
+        commaObject,
+      }),
+      QS.space({
+        spaceDelimited,
+      }),
+      QS.pipe({
+        pipeDelimited,
+      }),
+      QS.deep({
+        deepObject,
+      }),
+    )}`,
+    {
+      ...opts,
+    },
+  );
+}
+/**
+ * uploads an image in png format
+ */
+export function uploadPng(
+  {
+    body,
+  }: {
+    body?: Blob;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: ApiResponse;
+  }>("/uploadPng", {
+    ...opts,
+    method: "POST",
+    body,
+  });
+}
+export function issue330(
+  {
+    body,
+  }: {
+    body?: string;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchText(
+    "issue330",
+    oazapfts.json({
+      ...opts,
+      method: "PUT",
+      body,
+    }),
+  );
+}
+export function getIssue367(opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: {
+      foo?: EnumToRef;
+    };
+  }>("/issue367", {
+    ...opts,
+  });
+}
+export function productsGetAll(opts?: Oazapfts.RequestOpts) {
+  return oazapfts.fetchJson<
+    | {
+        status: 200;
+        data: PagedListOfProductRead;
+      }
+    | {
+        status: 210;
+        data: ProductRead & {
+          producerId: string;
+        };
+      }
+  >("/issue-446", {
+    ...opts,
+  });
+}
+export function productsCreateMany(
+  {
+    body,
+  }: {
+    body?: PagedListOfProductWrite | Pet;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: {};
+  }>(
+    "/issue-446",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body,
+    }),
+  );
+}
+export function readWriteMixed(
+  {
+    readWriteMixed,
+  }: {
+    readWriteMixed?: ReadWriteMixedWrite;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: ReadWriteMixedRead;
+  }>(
+    "issue-453",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: readWriteMixed,
+    }),
+  );
+}

--- a/demo/objectStyleArgument.ts
+++ b/demo/objectStyleArgument.ts
@@ -115,6 +115,11 @@ export type ReadWriteMixedWrite = {
   email: string;
   password: string;
 };
+export type Issue542 = {
+  playlist?: string;
+  "media-protocol"?: "hls" | "mss" | "dash";
+  "dashed-property"?: string;
+};
 /**
  * Update an existing pet
  */
@@ -313,10 +318,9 @@ export function deletePet(
   return oazapfts.fetchText(`/pet/${encodeURIComponent(petId)}`, {
     ...opts,
     method: "DELETE",
-    headers: {
-      ...(opts && opts.headers),
+    headers: oazapfts.mergeHeaders(opts?.headers, {
       api_key: apiKey,
-    },
+    }),
   });
 }
 /**
@@ -375,10 +379,9 @@ export function customizePet(
     {
       ...opts,
       method: "POST",
-      headers: {
-        ...(opts && opts.headers),
+      headers: oazapfts.mergeHeaders(opts?.headers, {
         "x-color-options": xColorOptions,
-      },
+      }),
     },
   );
 }
@@ -826,6 +829,28 @@ export function readWriteMixed(
       ...opts,
       method: "POST",
       body: readWriteMixed,
+    }),
+  );
+}
+export function dashInSchema(
+  {
+    issue542,
+  }: {
+    issue542?: Issue542;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: {
+      underscore_property?: "one" | "two" | "three";
+    };
+  }>(
+    "/issue-542",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: issue542,
     }),
   );
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:unit": "jest",
     "test:e2e": "npm run generate-demo && with-server 'cd demo && jest'",
     "start": "open-api-mocker -p $PORT -s demo/petstore.json",
-    "generate-demo": "npm run prepare && ./lib/codegen/cli.js ./demo/petstore.json ./demo/api.ts && ./lib/codegen/cli.js ./demo/petstore.json --mergeReadWriteOnly ./demo/mergedReadWriteApi.ts && ./lib/codegen/cli.js --optimistic ./demo/petstore.json ./demo/optimisticApi.ts && ./lib/codegen/cli.js --useEnumType ./demo/petstore.json ./demo/enumApi.ts && prettier -w demo",
+    "generate-demo": "npm run prepare && ./lib/codegen/cli.js ./demo/petstore.json ./demo/api.ts && ./lib/codegen/cli.js ./demo/petstore.json --mergeReadWriteOnly ./demo/mergedReadWriteApi.ts && ./lib/codegen/cli.js --optimistic ./demo/petstore.json ./demo/optimisticApi.ts && ./lib/codegen/cli.js --useEnumType ./demo/petstore.json ./demo/enumApi.ts && ./lib/codegen/cli.js --argumentStyle=object ./demo/petstore.json ./demo/objectStyleArgument.ts prettier -w demo",
     "prepare": "npm run build && chmod +x ./lib/codegen/cli.js && husky install"
   },
   "keywords": [

--- a/src/codegen/cli.ts
+++ b/src/codegen/cli.ts
@@ -3,7 +3,7 @@
 import fs from "fs";
 import minimist from "minimist";
 
-import { generateSource, Opts } from "./";
+import { generateSource, Opts, optsArgumentStyles } from "./";
 
 const argv = minimist(process.argv.slice(2), {
   alias: {
@@ -11,6 +11,7 @@ const argv = minimist(process.argv.slice(2), {
     e: "exclude",
   },
   boolean: ["optimistic", "useEnumType", "mergeReadWriteOnly"],
+  string: ["argumentStyle"],
 });
 
 async function generate(spec: string, dest: string, opts: Opts) {
@@ -19,7 +20,14 @@ async function generate(spec: string, dest: string, opts: Opts) {
   else console.log(code);
 }
 
-const { include, exclude, optimistic, useEnumType, mergeReadWriteOnly } = argv;
+const {
+  include,
+  exclude,
+  optimistic,
+  useEnumType,
+  mergeReadWriteOnly,
+  argumentStyle,
+} = argv;
 const [spec, dest] = argv._;
 if (!spec) {
   console.error(`
@@ -32,7 +40,20 @@ if (!spec) {
     --optimistic
     --useEnumType
     --mergeReadWriteOnly
+    --argumentStyle=<${optsArgumentStyles.join(" | ")}> (default: positional)
 `);
+  process.exit(1);
+}
+
+if (
+  argumentStyle !== undefined &&
+  !optsArgumentStyles.includes(argumentStyle)
+) {
+  console.error(
+    `--argumentStyle should be one of <${optsArgumentStyles.join(
+      " | ",
+    )}>, but got "${argumentStyle}"`,
+  );
   process.exit(1);
 }
 
@@ -42,4 +63,5 @@ generate(spec, dest, {
   optimistic,
   useEnumType,
   mergeReadWriteOnly,
+  argumentStyle,
 });

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -1314,6 +1314,11 @@ export default class ApiGenerator {
               );
             }
 
+            // if there's no params, leave methodParams as is and prevent empty object argument generation
+            if (paramMembers.length === 0) {
+              break;
+            }
+
             methodParams.push(
               cg.createParameter(
                 cg.createObjectBinding([

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -1204,9 +1204,6 @@ export default class ApiGenerator {
           ? supportDeepObjects(resolvedParameters)
           : resolvedParameters;
 
-        // split into required/optional
-        const [required, optional] = _.partition(parameters, "required");
-
         // convert parameter names to argument names ...
         const argNames = new Map<OpenAPIV3.ParameterObject, string>();
         _.sortBy(parameters, "name.length").forEach((p) => {
@@ -1224,57 +1221,116 @@ export default class ApiGenerator {
           return name;
         };
 
-        // build the method signature - first all the required parameters
-        const methodParams = required.map((p) =>
-          cg.createParameter(getArgName(this.resolve(p)), {
-            type: this.getTypeFromParameter(p),
-          }),
-        );
+        const methodParams: ts.ParameterDeclaration[] = [];
+        let body: OpenAPIV3.RequestBodyObject | undefined = undefined;
+        let bodyVar: string | undefined = undefined;
+        switch (this.opts.argumentStyle ?? "positional") {
+          case "positional":
+            // split into required/optional
+            const [required, optional] = _.partition(parameters, "required");
 
-        let body: OpenAPIV3.RequestBodyObject | undefined;
-        let bodyVar;
+            // build the method signature - first all the required parameters
+            const requiredParams = required.map((p) =>
+              cg.createParameter(getArgName(this.resolve(p)), {
+                type: this.getTypeFromParameter(p),
+              }),
+            );
+            methodParams.push(...requiredParams);
 
-        // add body if present
-        if (requestBody) {
-          body = this.resolve(requestBody);
-          const schema = this.getSchemaFromContent(body.content);
-          const type = this.getTypeFromSchema(schema, undefined, "writeOnly");
-          bodyVar = toIdentifier(
-            (type as any).name || getReferenceName(schema) || "body",
-          );
-          methodParams.push(
-            cg.createParameter(bodyVar, {
-              type,
-              questionToken: !body.required,
-            }),
-          );
-        }
+            // add body if present
+            if (requestBody) {
+              body = this.resolve(requestBody);
+              const schema = this.getSchemaFromContent(body.content);
+              const type = this.getTypeFromSchema(
+                schema,
+                undefined,
+                "writeOnly",
+              );
+              bodyVar = toIdentifier(
+                (type as any).name || getReferenceName(schema) || "body",
+              );
+              methodParams.push(
+                cg.createParameter(bodyVar, {
+                  type,
+                  questionToken: !body.required,
+                }),
+              );
+            }
 
-        // add an object with all optional parameters
-        if (optional.length) {
-          methodParams.push(
-            cg.createParameter(
-              cg.createObjectBinding(
-                optional
-                  .map((param) => this.resolve(param))
-                  .map((param) => ({ name: getArgName(param) })),
-              ),
-              {
-                initializer: factory.createObjectLiteralExpression(),
-                type: factory.createTypeLiteralNode(
-                  optional.map((p) =>
-                    cg.createPropertySignature({
-                      name: getArgName(this.resolve(p)),
-                      questionToken: true,
-                      type: this.getTypeFromParameter(p),
-                    }),
+            // add an object with all optional parameters
+            if (optional.length) {
+              methodParams.push(
+                cg.createParameter(
+                  cg.createObjectBinding(
+                    optional
+                      .map((param) => this.resolve(param))
+                      .map((param) => ({ name: getArgName(param) })),
                   ),
+                  {
+                    initializer: factory.createObjectLiteralExpression(),
+                    type: factory.createTypeLiteralNode(
+                      optional.map((p) =>
+                        cg.createPropertySignature({
+                          name: getArgName(this.resolve(p)),
+                          questionToken: true,
+                          type: this.getTypeFromParameter(p),
+                        }),
+                      ),
+                    ),
+                  },
                 ),
-              },
-            ),
-          );
+              );
+            }
+            break;
+
+          case "object":
+            // build the method signature - first all the required/optional parameters
+            const paramMembers = parameters.map((p) =>
+              cg.createPropertySignature({
+                name: getArgName(this.resolve(p)),
+                questionToken: !p.required,
+                type: this.getTypeFromParameter(p),
+              }),
+            );
+
+            // add body if present
+            if (requestBody) {
+              body = this.resolve(requestBody);
+              const schema = this.getSchemaFromContent(body.content);
+              const type = this.getTypeFromSchema(
+                schema,
+                undefined,
+                "writeOnly",
+              );
+              bodyVar = toIdentifier(
+                (type as any).name || getReferenceName(schema) || "body",
+              );
+              paramMembers.push(
+                cg.createPropertySignature({
+                  name: bodyVar,
+                  questionToken: !body.required,
+                  type,
+                }),
+              );
+            }
+
+            methodParams.push(
+              cg.createParameter(
+                cg.createObjectBinding([
+                  ...parameters
+                    .map((param) => this.resolve(param))
+                    .map((param) => ({ name: getArgName(param) })),
+                  ...(bodyVar ? [{ name: bodyVar }] : []),
+                ]),
+                {
+                  type: factory.createTypeLiteralNode(paramMembers),
+                },
+              ),
+            );
+            break;
         }
 
+        // add oazapfts options
         methodParams.push(
           cg.createParameter("opts", {
             type: factory.createTypeReferenceNode(

--- a/src/codegen/index.test.ts
+++ b/src/codegen/index.test.ts
@@ -236,12 +236,12 @@ describe("argumentStyle", () => {
     it("should generate positional argument", () => {
       // for path parameter and requestBody
       expect(src).toContain(
-        `function updatePetWithForm(petId: number, body?: { /** Updated name of the pet */ name?: string; /** Updated status of the pet */ status?: string; }, opts?: Oazapfts.RequestOpts)`,
+        `function updatePetWithForm(petId: number, body?: { /** Updated name of the pet */ name?: string; /** Updated status of the pet */ status?: string; }, opts?: Oazapfts.RequestOpts) { return oazapfts.fetchText(\`/pet/\${encodeURIComponent(petId)}\`, oazapfts.form({ ...opts, method: "POST", body })); }`,
       );
 
       // for query and header parameter
       expect(src).toContain(
-        `function customizePet(petId: number, { furColor, color, xColorOptions }: { furColor?: string; color?: string; xColorOptions?: boolean; } = {}, opts?: Oazapfts.RequestOpts) { return oazapfts.fetchText(\`/pet/\${encodeURIComponent(petId)}/customize\${QS.query(QS.explode({ "fur.color": furColor, color }))}\`, { ...opts, method: "POST", headers: { ...opts && opts.headers, "x-color-options": xColorOptions } }); }`,
+        `function customizePet(petId: number, { furColor, color, xColorOptions }: { furColor?: string; color?: string; xColorOptions?: boolean; } = {}, opts?: Oazapfts.RequestOpts) { return oazapfts.fetchText(\`/pet/\${encodeURIComponent(petId)}/customize\${QS.query(QS.explode({ "fur.color": furColor, color }))}\`, { ...opts, method: "POST", headers: oazapfts.mergeHeaders(opts?.headers, { "x-color-options": xColorOptions }) }); }`,
       );
     });
 
@@ -262,12 +262,12 @@ describe("argumentStyle", () => {
     it("should generate object argument", () => {
       // for path parameter and requestBody
       expect(src).toContain(
-        `function updatePetWithForm({ petId, body }: { petId: number; body?: { /** Updated name of the pet */ name?: string; /** Updated status of the pet */ status?: string; }; }, opts?: Oazapfts.RequestOpts)`,
+        `function updatePetWithForm({ petId, body }: { petId: number; body?: { /** Updated name of the pet */ name?: string; /** Updated status of the pet */ status?: string; }; }, opts?: Oazapfts.RequestOpts) { return oazapfts.fetchText(\`/pet/\${encodeURIComponent(petId)}\`, oazapfts.form({ ...opts, method: "POST", body })); }`,
       );
 
       // for query and header parameter
       expect(src).toContain(
-        `function customizePet({ petId, furColor, color, xColorOptions }: { petId: number; furColor?: string; color?: string; xColorOptions?: boolean; }, opts?: Oazapfts.RequestOpts) { return oazapfts.fetchText(\`/pet/\${encodeURIComponent(petId)}/customize\${QS.query(QS.explode({ "fur.color": furColor, color }))}\`, { ...opts, method: "POST", headers: { ...opts && opts.headers, "x-color-options": xColorOptions } }); }`,
+        `function customizePet({ petId, furColor, color, xColorOptions }: { petId: number; furColor?: string; color?: string; xColorOptions?: boolean; }, opts?: Oazapfts.RequestOpts) { return oazapfts.fetchText(\`/pet/\${encodeURIComponent(petId)}/customize\${QS.query(QS.explode({ "fur.color": furColor, color }))}\`, { ...opts, method: "POST", headers: oazapfts.mergeHeaders(opts?.headers, { "x-color-options": xColorOptions }) }); }`,
       );
     });
 

--- a/src/codegen/index.test.ts
+++ b/src/codegen/index.test.ts
@@ -234,8 +234,20 @@ describe("argumentStyle", () => {
     });
 
     it("should generate positional argument", () => {
+      // for path parameter and requestBody
       expect(src).toContain(
         `function updatePetWithForm(petId: number, body?: { /** Updated name of the pet */ name?: string; /** Updated status of the pet */ status?: string; }, opts?: Oazapfts.RequestOpts)`,
+      );
+
+      // for query and header parameter
+      expect(src).toContain(
+        `function customizePet(petId: number, { furColor, color, xColorOptions }: { furColor?: string; color?: string; xColorOptions?: boolean; } = {}, opts?: Oazapfts.RequestOpts) { return oazapfts.fetchText(\`/pet/\${encodeURIComponent(petId)}/customize\${QS.query(QS.explode({ "fur.color": furColor, color }))}\`, { ...opts, method: "POST", headers: { ...opts && opts.headers, "x-color-options": xColorOptions } }); }`,
+      );
+    });
+
+    it("should not generate argument when no parameters nor requestBody specified", () => {
+      expect(src).toContain(
+        `function getInventory(opts?: Oazapfts.RequestOpts) { return oazapfts.fetchJson<{ status: 200; data: { [key: string]: number; }; }>("/store/inventory", { ...opts }); }`,
       );
     });
   });
@@ -248,8 +260,20 @@ describe("argumentStyle", () => {
     });
 
     it("should generate object argument", () => {
+      // for path parameter and requestBody
       expect(src).toContain(
         `function updatePetWithForm({ petId, body }: { petId: number; body?: { /** Updated name of the pet */ name?: string; /** Updated status of the pet */ status?: string; }; }, opts?: Oazapfts.RequestOpts)`,
+      );
+
+      // for query and header parameter
+      expect(src).toContain(
+        `function customizePet({ petId, furColor, color, xColorOptions }: { petId: number; furColor?: string; color?: string; xColorOptions?: boolean; }, opts?: Oazapfts.RequestOpts) { return oazapfts.fetchText(\`/pet/\${encodeURIComponent(petId)}/customize\${QS.query(QS.explode({ "fur.color": furColor, color }))}\`, { ...opts, method: "POST", headers: { ...opts && opts.headers, "x-color-options": xColorOptions } }); }`,
+      );
+    });
+
+    it("should not generate argument when no parameters nor requestBody specified", () => {
+      expect(src).toContain(
+        `function getInventory(opts?: Oazapfts.RequestOpts) { return oazapfts.fetchJson<{ status: 200; data: { [key: string]: number; }; }>("/store/inventory", { ...opts }); }`,
       );
     });
   });

--- a/src/codegen/index.test.ts
+++ b/src/codegen/index.test.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { generateSource } from "./index";
+import { Opts, generateSource } from "./index";
 
 import { createProject, ts } from "@ts-morph/bootstrap";
 import { ScriptTarget } from "typescript";
@@ -7,7 +7,7 @@ import { ScriptTarget } from "typescript";
 /**
  * Generate an API from a relative path and convert it into a single line.
  */
-async function generate(file: string, opts = {}) {
+async function generate(file: string, opts: Opts = {}) {
   const spec = path.join(__dirname, file);
   const src = await generateSource(spec, opts);
   const error = await checkForTypeErrors(src);
@@ -220,5 +220,37 @@ describe("useEnumType", () => {
     expect(src).toContain(
       `export enum Category2 { Rich = "rich", Wealthy = "wealthy", Poor = "poor" }`,
     );
+  });
+});
+
+describe("argumentStyle", () => {
+  let src: string;
+
+  describe("positional", () => {
+    beforeAll(async () => {
+      src = await generate("/../../demo/petstore.json", {
+        argumentStyle: "positional",
+      });
+    });
+
+    it("should generate positional argument", () => {
+      expect(src).toContain(
+        `function updatePetWithForm(petId: number, body?: { /** Updated name of the pet */ name?: string; /** Updated status of the pet */ status?: string; }, opts?: Oazapfts.RequestOpts)`,
+      );
+    });
+  });
+
+  describe("object", () => {
+    beforeAll(async () => {
+      src = await generate("/../../demo/petstore.json", {
+        argumentStyle: "object",
+      });
+    });
+
+    it("should generate object argument", () => {
+      expect(src).toContain(
+        `function updatePetWithForm({ petId, body }: { petId: number; body?: { /** Updated name of the pet */ name?: string; /** Updated status of the pet */ status?: string; }; }, opts?: Oazapfts.RequestOpts)`,
+      );
+    });
   });
 });

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -7,6 +7,7 @@ import { OpenAPI, OpenAPIV3 } from "openapi-types";
 
 export { cg };
 
+export const optsArgumentStyles = ["positional", "object"];
 export type Opts = {
   include?: string[];
   exclude?: string[];
@@ -14,6 +15,7 @@ export type Opts = {
   unionUndefined?: boolean;
   useEnumType?: boolean;
   mergeReadWriteOnly?: boolean;
+  argumentStyle?: (typeof optsArgumentStyles)[number];
 };
 
 export function generateAst(


### PR DESCRIPTION
## abstract

This PR adds an option that lets us opt in to object style argument by `--argumentStyle=object`:

```typescript
export function updatePetWithForm({ petId, body }: {
    petId: number;
    body?: {
        /** Updated name of the pet */
        name?: string;
        /** Updated status of the pet */
        status?: string;
    };
}, opts?: Oazapfts.RequestOpts) {
    return oazapfts.fetchText(`/pet/${encodeURIComponent(petId)}`, oazapfts.form({
        ...opts,
        method: "POST",
        body
    }));
}
```

as opposed to `--argumentStyle=positional` one (which is default):

```typescript
export function updatePetWithForm(petId: number, body?: {
    /** Updated name of the pet */
    name?: string;
    /** Updated status of the pet */
    status?: string;
}, opts?: Oazapfts.RequestOpts) {
    return oazapfts.fetchText(`/pet/${encodeURIComponent(petId)}`, oazapfts.form({
        ...opts,
        method: "POST",
        body
    }));
}
```

## motivation

- most of other libraries support this by default or as opt-in, and I guess not few ppl like this style
- sometimes it's kinder to typing (e.g. we can now derive the type of whole request param by `Parameters<typeof func>[0]`, instead of struggling with a tuple of variable length)

## a few other points

- while the word `positional` argument is somewhat canonical, couldn't find good one for `object` style (technically speaking this is just destructuring assignment in function argument)
- didn't take care of property name duplication between requestBody and parameters, I'll add the logic if this is crucial
- additional tests are pretty minimal, tell me if there's any important cases
- in my initial implementation, the object argument types were defined as separate type aliases and `export`-ed, if this is wanted I'm happy to revert this behavior but as another option, maybe `--argumentStyle=objectExported`, or add new one like `--exportObjcectArgumentTypes=true`

P.S. Thanks for the great work. As far as I know, oazapfts is the best option for openapi ts codegen out there, in terms of generated code tidiness, supported openapi features (kudos to readOnly/writeOnly support) and all. I think this library should get more attention.