### PR TITLE
fix: move default exports to bottom

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,33 +5,33 @@
   "main": "lib/index.js",
   "exports": {
     "./lib/runtime": {
-      "require": "./lib/runtime/index.js",
       "types": "./lib/runtime/index.d.ts",
+      "require": "./lib/runtime/index.js",
       "default": "./lib/runtime/index.js"
     },
     "./lib/runtime/query": {
-      "require": "./lib/runtime/query.js",
       "types": "./lib/runtime/query.d.js",
+      "require": "./lib/runtime/query.js",
       "default": "./lib/runtime/query.js"
     },
     "./lib/runtime/index.js": {
-      "require": "./lib/runtime/index.js",
       "types": "./lib/runtime/index.d.ts",
+      "require": "./lib/runtime/index.js",
       "default": "./lib/runtime/index.js"
     },
     "./lib/runtime/query.js": {
-      "require": "./lib/runtime/query.js",
       "types": "./lib/runtime/query.d.js",
+      "require": "./lib/runtime/query.js",
       "default": "./lib/runtime/query.js"
     },
     "./runtime": {
-      "require": "./lib/runtime/index.js",
       "types": "./lib/runtime/index.d.ts",
+      "require": "./lib/runtime/index.js",
       "default": "./lib/runtime/index.js"
     },
     "./runtime/query": {
-      "require": "./lib/runtime/query.js",
       "types": "./lib/runtime/query.d.js",
+      "require": "./lib/runtime/query.js",
       "default": "./lib/runtime/query.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -6,33 +6,33 @@
   "exports": {
     "./lib/runtime": {
       "require": "./lib/runtime/index.js",
-      "default": "./lib/runtime/index.js",
-      "types": "./lib/runtime/index.d.ts"
+      "types": "./lib/runtime/index.d.ts",
+      "default": "./lib/runtime/index.js"
     },
     "./lib/runtime/query": {
       "require": "./lib/runtime/query.js",
-      "default": "./lib/runtime/query.js",
-      "types": "./lib/runtime/query.d.js"
+      "types": "./lib/runtime/query.d.js",
+      "default": "./lib/runtime/query.js"
     },
     "./lib/runtime/index.js": {
       "require": "./lib/runtime/index.js",
-      "default": "./lib/runtime/index.js",
-      "types": "./lib/runtime/index.d.ts"
+      "types": "./lib/runtime/index.d.ts",
+      "default": "./lib/runtime/index.js"
     },
     "./lib/runtime/query.js": {
       "require": "./lib/runtime/query.js",
-      "default": "./lib/runtime/query.js",
-      "types": "./lib/runtime/query.d.js"
+      "types": "./lib/runtime/query.d.js",
+      "default": "./lib/runtime/query.js"
     },
     "./runtime": {
       "require": "./lib/runtime/index.js",
-      "default": "./lib/runtime/index.js",
-      "types": "./lib/runtime/index.d.ts"
+      "types": "./lib/runtime/index.d.ts",
+      "default": "./lib/runtime/index.js"
     },
     "./runtime/query": {
       "require": "./lib/runtime/query.js",
-      "default": "./lib/runtime/query.js",
-      "types": "./lib/runtime/query.d.js"
+      "types": "./lib/runtime/query.d.js",
+      "default": "./lib/runtime/query.js"
     }
   },
   "bin": {


### PR DESCRIPTION
The changes made in https://github.com/oazapfts/oazapfts/commit/768ddd404ea256a46b92af949e444133119c5bd6 broke my build with the following webpack error after running `next build`:

```ts
Module not found: Default condition should be last one
   6 |  * See https://www.npmjs.com/package/oazapfts
   7 |  */
>  8 | import * as Oazapfts from "oazapfts/lib/runtime";
   9 | import * as QS from "oazapfts/lib/runtime/query";
  10 | export const defaults: Oazapfts.Defaults<Oazapfts.CustomHeaders> = {
  11 |     headers: {},

https://nextjs.org/docs/messages/module-not-found
```

According to the [webpack documentation](https://webpack.js.org/guides/package-exports/#conditional-syntax):
> The last condition in the object might be the special "default" condition, which is always matched.

Since the `default` condition was not the last one, the error above occurred. This PR moves all `default` conditions to the bottom which should resolve this error.