### PR TITLE
perf: reduce runtime size by using esnext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,10 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
-    "target": "es2015",
+    "target": "esnext",
     "sourceMap": true,
     "declaration": true,
-    "lib": ["es2015", "dom"],
+    "lib": ["esnext", "dom"],
     "module": "commonjs",
     "strict": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
This simplifies the generated code a fair amount. E.g. consider the example below:

On `main`:
```js
    function fetchText(url, req) {
        return __awaiter(this, void 0, void 0, function* () {
            const res = yield doFetch(url, req);
            let data;
            try {
                data = yield res.text();
            }
            catch (err) { }
            return {
                status: res.status,
                headers: res.headers,
                contentType: res.headers.get("content-type"),
                data,
            };
        });
    }
```

With this PR:
```js
    async function fetchText(url, req) {
        const res = await doFetch(url, req);
        let data;
        try {
            data = await res.text();
        }
        catch (err) { }
        return {
            status: res.status,
            headers: res.headers,
            contentType: res.headers.get("content-type"),
            data,
        };
    }
```

It's always best for libraries to be distributed as `esnext` as it results in the smallest code. If someone is targeting an older browser or runtime they should be using the appropriate bundler setting to transpile to an older version while building their application rather than expecting each individual library they're using to do so.