### PR TITLE
fix: support boolean schemas

### DIFF
--- a/packages/codegen/src/__fixtures__/booleanSchema.json
+++ b/packages/codegen/src/__fixtures__/booleanSchema.json
@@ -1,0 +1,86 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Boolean schema example",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/blog/{id}": {
+      "get": {
+        "tags": ["blog"],
+        "summary": "Get blog entry by ID",
+        "description": "Returns a single blog entry",
+        "operationId": "getBlogEntryById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of blog entry",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BlogEntry"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/explode": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Paradox"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BlogEntry": {
+        "type": "object",
+        "required": ["id", "title", "content"],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": true
+        },
+        "additionalProperties": false
+      },
+      "Paradox": {
+        "type": "object",
+        "required": ["foo"],
+        "properties": {
+          "foo": false
+        }
+      }
+    }
+  }
+}

--- a/packages/codegen/src/__fixtures__/booleanSchemaRefs.json
+++ b/packages/codegen/src/__fixtures__/booleanSchemaRefs.json
@@ -1,0 +1,92 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Boolean schema example",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/blog/{id}": {
+      "get": {
+        "tags": ["blog"],
+        "summary": "Get blog entry by ID",
+        "description": "Returns a single blog entry",
+        "operationId": "getBlogEntryById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of blog entry",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BlogEntry"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/explode": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Paradox"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BlogEntry": {
+        "type": "object",
+        "required": ["id", "title", "content"],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "$ref": "#/components/schemas/AlwaysAccept"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Paradox": {
+        "type": "object",
+        "required": ["foo"],
+        "properties": {
+          "foo": {
+            "$ref": "#/components/schemas/NeverAccept"
+          }
+        }
+      },
+      "AlwaysAccept": true,
+      "NeverAccept": false
+    }
+  }
+}

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -477,7 +477,7 @@ export default class ApiGenerator {
             type,
           }),
         );
-        return this.refs[$ref].base;
+        return typeReferenceNode.base;
       }
 
       if (ignoreDiscriminator) {

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -457,12 +457,16 @@ export default class ApiGenerator {
 
     if (!this.refs[$ref]) {
       let schema = this.resolve<SchemaObject>(obj);
-      if (typeof schema !== "boolean" && ignoreDiscriminator) {
+
+      if (typeof schema === "boolean") {
+        return this.refs[$ref].base;
+      }
+
+      if (ignoreDiscriminator) {
         schema = _.cloneDeep(schema);
         delete schema.discriminator;
       }
-      const name =
-        (typeof schema !== "boolean" && schema.title) || getRefName($ref);
+      const name = schema.title || getRefName($ref);
       const identifier = toIdentifier(name, true);
 
       // When this is a true enum we can reference it directly,

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -458,33 +458,12 @@ export default class ApiGenerator {
     if (!this.refs[$ref]) {
       let schema = this.resolve<SchemaObject>(obj);
 
-      if (typeof schema === "boolean") {
-        const name = getRefName($ref);
-        const identifier = toIdentifier(name, true);
-        const alias = this.getUniqueAlias(identifier);
-        const type = this.getTypeFromSchema(schema, undefined);
-        const typeReferenceNode = {
-          base: factory.createTypeReferenceNode(alias, undefined),
-          // `readOnly` and `writeOnly` are not applicable to boolean schemas
-          readOnly: undefined,
-          writeOnly: undefined,
-        };
-        this.refs[$ref] = typeReferenceNode;
-        this.aliases.push(
-          cg.createTypeAliasDeclaration({
-            modifiers: [cg.modifier.export],
-            name: alias,
-            type,
-          }),
-        );
-        return typeReferenceNode.base;
-      }
-
-      if (ignoreDiscriminator) {
+      if (typeof schema !== "boolean" && ignoreDiscriminator) {
         schema = _.cloneDeep(schema);
         delete schema.discriminator;
       }
-      const name = schema.title || getRefName($ref);
+      const name =
+        (typeof schema !== "boolean" && schema.title) || getRefName($ref);
       const identifier = toIdentifier(name, true);
 
       // When this is a true enum we can reference it directly,

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -459,6 +459,24 @@ export default class ApiGenerator {
       let schema = this.resolve<SchemaObject>(obj);
 
       if (typeof schema === "boolean") {
+        const name = getRefName($ref);
+        const identifier = toIdentifier(name, true);
+        const alias = this.getUniqueAlias(identifier);
+        const type = this.getTypeFromSchema(schema, undefined);
+        const typeReferenceNode = {
+          base: factory.createTypeReferenceNode(alias, undefined),
+          // `readOnly` and `writeOnly` are not applicable to boolean schemas
+          readOnly: undefined,
+          writeOnly: undefined,
+        };
+        this.refs[$ref] = typeReferenceNode;
+        this.aliases.push(
+          cg.createTypeAliasDeclaration({
+            modifiers: [cg.modifier.export],
+            name: alias,
+            type,
+          }),
+        );
         return this.refs[$ref].base;
       }
 

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -820,8 +820,8 @@ export default class ApiGenerator {
     with a new name adding a number
   */
   getTrueEnum(schema: SchemaObject, propName: string) {
-    if (typeof schema == "boolean") {
-      // HACK: this should never be thrown, since the only `getTrueEnum` call is
+    if (typeof schema === "boolean") {
+      // this should never be thrown, since the only `getTrueEnum` call is
       // behind an `isTrueEnum` check, which returns false for boolean schemas.
       throw new Error(
         "cannot get enum from boolean schema. schema must be an object",
@@ -1164,7 +1164,7 @@ export default class ApiGenerator {
     // First scan: Add `x-component-ref-path` property and record discriminating schemas
     for (const name of Object.keys(schemas)) {
       const schema = schemas[name];
-      if (isReference(schema)) continue;
+      if (isReference(schema) || typeof schema === "boolean") continue;
 
       schema["x-component-ref-path"] = prefix + name;
 

--- a/packages/codegen/src/index.test.ts
+++ b/packages/codegen/src/index.test.ts
@@ -88,7 +88,6 @@ describe("generateSource", () => {
 
   it("should support boolean schemas", async () => {
     const src = await generate(__dirname + "/__fixtures__/booleanSchema.json");
-    console.log(src);
     expect(src).toContain(
       "export type BlogEntry = { id: number; title: string; content: any | null; };",
     );

--- a/packages/codegen/src/index.test.ts
+++ b/packages/codegen/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, assert } from "vitest";
 import * as path from "node:path";
 import { Opts, generateSource } from "./index";
 import { readFile } from "node:fs/promises";
@@ -92,6 +92,13 @@ describe("generateSource", () => {
       "export type BlogEntry = { id: number; title: string; content: any | null; };",
     );
     expect(src).toContain("export type Paradox = { foo: never; };");
+  });
+
+  it("should support referenced boolean schemas", async () => {
+    const src = await generate(
+      __dirname + "/__fixtures__/booleanSchemaRefs.json",
+    );
+    assert.fail("not implemented");
   });
 
   it("should handle application/geo+json", async () => {

--- a/packages/codegen/src/index.test.ts
+++ b/packages/codegen/src/index.test.ts
@@ -98,7 +98,12 @@ describe("generateSource", () => {
     const src = await generate(
       __dirname + "/__fixtures__/booleanSchemaRefs.json",
     );
-    assert.fail("not implemented");
+    expect(src).toContain(
+      "export type BlogEntry = { id: number; title: string; content: AlwaysAccept; };",
+    );
+    expect(src).toContain("export type Paradox = { foo: NeverAccept; };");
+    expect(src).toContain("export type AlwaysAccept = any | null;");
+    expect(src).toContain("export type NeverAccept = never;");
   });
 
   it("should handle application/geo+json", async () => {

--- a/packages/codegen/src/index.test.ts
+++ b/packages/codegen/src/index.test.ts
@@ -86,6 +86,15 @@ describe("generateSource", () => {
     );
   });
 
+  it("should support boolean schemas", async () => {
+    const src = await generate(__dirname + "/__fixtures__/booleanSchema.json");
+    console.log(src);
+    expect(src).toContain(
+      "export type BlogEntry = { id: number; title: string; content: any | null; };",
+    );
+    expect(src).toContain("export type Paradox = { foo: never; };");
+  });
+
   it("should handle application/geo+json", async () => {
     const src = await generate(__dirname + "/__fixtures__/geojson.json");
     expect(src).toContain(

--- a/packages/codegen/src/tscodegen.ts
+++ b/packages/codegen/src/tscodegen.ts
@@ -19,6 +19,7 @@ export const keywordType = {
   boolean: factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
   undefined: factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
   void: factory.createKeywordTypeNode(ts.SyntaxKind.VoidKeyword),
+  never: factory.createKeywordTypeNode(ts.SyntaxKind.NeverKeyword),
   null: factory.createLiteralTypeNode(factory.createNull()),
 };
 


### PR DESCRIPTION
oazapfts codegen fails if the api contains [boolean json schema](https://json-schema.org/draft/2020-12/json-schema-core#section-4.3.2).

```jsonc
{
  // ...
  "schemas": {
    "Foo": {
      "type": "object",
      "required": ["bar"],
      "properties": {
        "bar": true
      },
      "additionalProperties": false
    }
  }
}
```

This PR adds support for these, mapping `true` to `any` and `false` to `never`.

I am not sure about how this should behave with "TrueEnums" (~~not sure what that is~~ i get it now, these are typescript enums), so please review with extra care, as I am not familiar with the codebase and don't understand every corner of it.

This is an upstream issue with `kogosoftwarellc/open-api`, which is also missing boolean schema support (I filed a PR to fix this at kogosoftwarellc/open-api#902).