### PR TITLE
fix(codegen): create negative numbers with createNumericLiteral in combination with createPrefixUnaryExpression

### DIFF
--- a/packages/codegen/src/tscodegen.ts
+++ b/packages/codegen/src/tscodegen.ts
@@ -40,7 +40,11 @@ export function createLiteral(v: string | boolean | number) {
     case "boolean":
       return v ? factory.createTrue() : factory.createFalse();
     case "number":
-      return factory.createNumericLiteral(String(v));
+      return String(v).charAt(0) === "-" ?
+        factory.createPrefixUnaryExpression(
+          ts.SyntaxKind.MinusToken,
+          factory.createNumericLiteral(String(-v))
+        ) : factory.createNumericLiteral(String(v))
   }
 }
 

--- a/packages/codegen/src/tscodegen.ts
+++ b/packages/codegen/src/tscodegen.ts
@@ -40,11 +40,12 @@ export function createLiteral(v: string | boolean | number) {
     case "boolean":
       return v ? factory.createTrue() : factory.createFalse();
     case "number":
-      return String(v).charAt(0) === "-" ?
-        factory.createPrefixUnaryExpression(
-          ts.SyntaxKind.MinusToken,
-          factory.createNumericLiteral(String(-v))
-        ) : factory.createNumericLiteral(String(v))
+      return String(v).charAt(0) === "-"
+        ? factory.createPrefixUnaryExpression(
+            ts.SyntaxKind.MinusToken,
+            factory.createNumericLiteral(String(-v)),
+          )
+        : factory.createNumericLiteral(String(v));
   }
 }
 


### PR DESCRIPTION
Fixes #626

Typescript >= 5.4 raises an error when using the method createNumericLiteral with a negative number
https://github.com/microsoft/TypeScript/blob/v5.4-rc/src/compiler/factory/nodeFactory.ts#L1257

This pr uses createPrefixUnaryExpression in combination with createNumericLiteral to handle negative numbers.