### PR TITLE
discriminated unions with enum variant

### DIFF
--- a/packages/codegen/src/generate.test.ts
+++ b/packages/codegen/src/generate.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { getOperationName, isJsonMimeType, isMimeType } from "./generate";
+import ApiGenerator, {
+  OpenAPIDocument,
+  getOperationName,
+  isJsonMimeType,
+  isMimeType,
+} from "./generate";
+import { printNode } from "./tscodegen";
+import { OpenAPIV3 } from "openapi-types";
 
 describe("getOperationName", () => {
   it("should use the id", () => {
@@ -33,5 +40,92 @@ describe("content types", () => {
     expect(isJsonMimeType("application/json+foo")).toBe(true);
     expect(isJsonMimeType("*/*")).toBe(true);
     expect(isJsonMimeType("text/plain")).toBe(false);
+  });
+});
+
+describe("getUnionType", () => {
+  describe("discriminator with propertyName", () => {
+    describe("propertyName doesn’t exists", () => {
+      it("should use the schema’s name as variant name", () => {
+        const spec = {
+          components: {
+            schemas: {
+              LoginSuccess: {
+                type: "object",
+                properties: {},
+              },
+              LoginRedirect: {
+                type: "object",
+                properties: {},
+              },
+            },
+          },
+        } as unknown as OpenAPIV3.Document;
+        const generator = new ApiGenerator(spec);
+        const variants = [
+          {
+            $ref: "#/components/schemas/LoginSuccess",
+          },
+          {
+            $ref: "#/components/schemas/LoginRedirect",
+          },
+        ];
+
+        const discriminator = { propertyName: "response_type" };
+        const unionTypeNode = generator.getUnionType(variants, discriminator);
+        const result = printNode(unionTypeNode);
+        expect(result).toBe(`({
+    response_type: "LoginSuccess";
+} & LoginSuccess) | ({
+    response_type: "LoginRedirect";
+} & LoginRedirect)`);
+      });
+    });
+    describe("propertyName exists and leads to an enum", () => {
+      it("should use the enum given as variant name", () => {
+        const spec = {
+          components: {
+            schemas: {
+              LoginSuccess: {
+                type: "object",
+                properties: {
+                  response_type: {
+                    type: "string",
+                    enum: ["success"],
+                  },
+                },
+              },
+              LoginRedirect: {
+                type: "object",
+                properties: {
+                  response_type: {
+                    type: "string",
+                    enum: ["redirect"],
+                  },
+                },
+              },
+            },
+          },
+        } as unknown as OpenAPIV3.Document;
+        const generator = new ApiGenerator(spec);
+        const variants = [
+          {
+            $ref: "#/components/schemas/LoginSuccess",
+          },
+          {
+            $ref: "#/components/schemas/LoginRedirect",
+          },
+        ];
+
+        const discriminator = { propertyName: "response_type" };
+        const unionTypeNode = generator.getUnionType(variants, discriminator);
+        const result = printNode(unionTypeNode);
+        expect(result).toBe(`({
+    response_type: "success";
+} & LoginSuccess) | ({
+    response_type: "redirect";
+} & LoginRedirect)`);
+      });
+    });
   });
 });

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -37,7 +37,7 @@ type OpenAPIReferenceObject =
 type OpenAPIParameterObject =
   | OpenAPIV3.ParameterObject
   | OpenAPIV3_1.ParameterObject;
-type OpenAPIDocument = OpenAPIV3.Document | OpenAPIV3_1.Document;
+export type OpenAPIDocument = OpenAPIV3.Document | OpenAPIV3_1.Document;
 type OpenAPIDiscriminatorObject =
   | OpenAPIV3.DiscriminatorObject
   | OpenAPIV3_1.DiscriminatorObject;
@@ -571,10 +571,19 @@ export default class ApiGenerator {
                 }
                 return !mappedValues.has(getRefBasename(variant.$ref));
               })
-              .map((schema) => [
-                getRefBasename((schema as OpenAPIReferenceObject).$ref),
-                schema,
-              ]),
+              .map((schema) => {
+                const schemaBaseName = getRefBasename(
+                  (schema as OpenAPIV3.ReferenceObject).$ref,
+                );
+                const resolvedSchema = this.resolve(schema) as OpenAPIV3.SchemaObject;
+                const discriminatorProperty =
+                  resolvedSchema.properties?.[discriminator.propertyName];
+                const variantName =
+                  discriminatorProperty && 'enum' in discriminatorProperty
+                    ? discriminatorProperty?.enum?.[0]
+                    : '';
+                return [variantName || schemaBaseName, schema];
+              }),
           ] as [string, OpenAPIReferenceObject][]
         ).map(([discriminatorValue, variant]) =>
           // Yields: { [discriminator.propertyName]: discriminatorValue } & variant


### PR DESCRIPTION
In a discriminated union, use the provided variant name instead of the schema`s name. use the Schema’s name only if it’s not provided.

For example, here the variant name `standard` is given, and is used instead of the schema’s name `StandardAllowance` (which was previously used, and would result in invalid, empty type (because the string has to match discriminated union with 

```yaml
    Allowance:
      oneOf:
        - $ref: "#/components/schemas/EngineeringAllowance"
        - $ref: "#/components/schemas/StandardAllowance"
      discriminator:
        propertyName: allowance_type
```


```yaml
    StandardAllowance:
      properties:
        allowance_type:
          type: string
          enum: ["standard"]
```

This now creates a valid discriminated union. The `allowance_type` field in the variants matches with the `allowance_type` in the discriminated unions :

```ts
export type EngineeringAllowance = {
  allowance_type?: 'engineering';
  distribution?: 'MARECO' | 'LINEAR';
  capacity_speed_limit?: number;
} & RangeAllowance;
export type StandardAllowance = {
  allowance_type?: 'standard';
  default_value?: AllowanceValue;
  ranges?: RangeAllowance[];
  distribution?: 'MARECO' | 'LINEAR';
  capacity_speed_limit?: number;
};
export type Allowance =
  | ({
      allowance_type: 'engineering';
    } & EngineeringAllowance)
  | ({
      allowance_type: 'standard';
    } & StandardAllowance);
```

fixes: https://github.com/reduxjs/redux-toolkit/issues/3369
