### PR TITLE
fix: ignore undefined discriminator mapping

### DIFF
--- a/demo/api.ts
+++ b/demo/api.ts
@@ -129,6 +129,7 @@ export type Issue542 = {
   "media-protocol"?: "hls" | "mss" | "dash";
   "dashed-property"?: string;
 };
+export type Issue672 = {};
 /**
  * Update an existing pet
  */
@@ -739,6 +740,22 @@ export function dashInSchema(issue542?: Issue542, opts?: Oazapfts.RequestOpts) {
       ...opts,
       method: "POST",
       body: issue542,
+    }),
+  );
+}
+export function undefinedDiscriminatorMapping(
+  issue672: Issue672,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: Pet;
+  }>(
+    "/issue-672",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: issue672,
     }),
   );
 }

--- a/demo/enumApi.ts
+++ b/demo/enumApi.ts
@@ -128,6 +128,7 @@ export type Issue542 = {
   "media-protocol"?: MediaProtocol;
   "dashed-property"?: string;
 };
+export type Issue672 = {};
 /**
  * Update an existing pet
  */
@@ -738,6 +739,22 @@ export function dashInSchema(issue542?: Issue542, opts?: Oazapfts.RequestOpts) {
       ...opts,
       method: "POST",
       body: issue542,
+    }),
+  );
+}
+export function undefinedDiscriminatorMapping(
+  issue672: Issue672,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: Pet;
+  }>(
+    "/issue-672",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: issue672,
     }),
   );
 }

--- a/demo/mergedReadWriteApi.ts
+++ b/demo/mergedReadWriteApi.ts
@@ -102,6 +102,7 @@ export type Issue542 = {
   "media-protocol"?: "hls" | "mss" | "dash";
   "dashed-property"?: string;
 };
+export type Issue672 = {};
 /**
  * Update an existing pet
  */
@@ -713,6 +714,22 @@ export function dashInSchema(issue542?: Issue542, opts?: Oazapfts.RequestOpts) {
       ...opts,
       method: "POST",
       body: issue542,
+    }),
+  );
+}
+export function undefinedDiscriminatorMapping(
+  issue672: Issue672,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: Pet;
+  }>(
+    "/issue-672",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: issue672,
     }),
   );
 }

--- a/demo/objectStyleArgument.ts
+++ b/demo/objectStyleArgument.ts
@@ -129,6 +129,7 @@ export type Issue542 = {
   "media-protocol"?: "hls" | "mss" | "dash";
   "dashed-property"?: string;
 };
+export type Issue672 = {};
 /**
  * Update an existing pet
  */
@@ -880,6 +881,26 @@ export function dashInSchema(
       ...opts,
       method: "POST",
       body: issue542,
+    }),
+  );
+}
+export function undefinedDiscriminatorMapping(
+  {
+    issue672,
+  }: {
+    issue672: Issue672;
+  },
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.fetchJson<{
+    status: 200;
+    data: Pet;
+  }>(
+    "/issue-672",
+    oazapfts.json({
+      ...opts,
+      method: "POST",
+      body: issue672,
     }),
   );
 }

--- a/demo/optimisticApi.ts
+++ b/demo/optimisticApi.ts
@@ -129,6 +129,7 @@ export type Issue542 = {
   "media-protocol"?: "hls" | "mss" | "dash";
   "dashed-property"?: string;
 };
+export type Issue672 = {};
 /**
  * Update an existing pet
  */
@@ -800,6 +801,24 @@ export function dashInSchema(issue542?: Issue542, opts?: Oazapfts.RequestOpts) {
         ...opts,
         method: "POST",
         body: issue542,
+      }),
+    ),
+  );
+}
+export function undefinedDiscriminatorMapping(
+  issue672: Issue672,
+  opts?: Oazapfts.RequestOpts,
+) {
+  return oazapfts.ok(
+    oazapfts.fetchJson<{
+      status: 200;
+      data: Pet;
+    }>(
+      "/issue-672",
+      oazapfts.json({
+        ...opts,
+        method: "POST",
+        body: issue672,
       }),
     ),
   );

--- a/demo/petstore.json
+++ b/demo/petstore.json
@@ -1282,6 +1282,35 @@
           }
         }
       }
+    },
+    "/issue-672": {
+      "post": {
+        "operationId": "UndefinedDiscriminatorMapping",
+        "parameters": [],
+        "requestBody": {
+          "description": "Pet object that needs to be added to the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Issue672"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1581,6 +1610,12 @@
             "type": "string"
           }
         }
+      },
+      "Issue672": {
+        "required": ["@type"],
+        "type": "object",
+        "properties": {},
+        "discriminator": { "propertyName": "@type" }
       }
     },
     "securitySchemes": {

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -660,9 +660,9 @@ export default class ApiGenerator {
       // anyOf -> union
       return this.getUnionType(schema.anyOf, undefined, onlyMode);
     }
-    if (schema.discriminator) {
+    if (schema.discriminator?.mapping) {
       // discriminating schema -> union
-      const mapping = schema.discriminator.mapping || {};
+      const mapping = schema.discriminator.mapping;
       return this.getUnionType(
         Object.values(mapping).map((ref) => ({ $ref: ref })),
         undefined,


### PR DESCRIPTION
Ran into an issue trying to generate types for a schema that had a discriminator defined without mapping. The missing mapping was caused by the generated OpenAPI spec having poorly parsed inheritance.

The following will result in `export type MyAlias = ;`, with the conditional change it will fall back to `export type MyAlias = {};`
```json
 "MyAlias": {
        "required": ["@type"],
        "type": "object",
        "properties": {},
        "discriminator": { "propertyName": "@type" }
      },
``` 