### PR TITLE
fix: negative numeric values in enums

### DIFF
--- a/demo/api.ts
+++ b/demo/api.ts
@@ -44,7 +44,7 @@ export type Pet = {
   /** Size scale for pets */
   size?: "P" | "M" | "G" | "0";
   /** integer test case for #349 */
-  typeId?: 1 | 2 | 3 | 4 | 6 | 8;
+  typeId?: 1 | 2 | 3 | 4 | 6 | 8 | -1;
 };
 export type ApiResponse = {
   code?: number;

--- a/demo/enumApi.ts
+++ b/demo/enumApi.ts
@@ -761,6 +761,7 @@ export enum TypeId {
   Mouse = 4,
   House = 6,
   $3HeadedMonkey = 8,
+  Unicorn = -1,
 }
 export enum Status2 {
   Placed = "placed",

--- a/demo/mergedReadWriteApi.ts
+++ b/demo/mergedReadWriteApi.ts
@@ -44,7 +44,7 @@ export type Pet = {
   /** Size scale for pets */
   size?: "P" | "M" | "G" | "0";
   /** integer test case for #349 */
-  typeId?: 1 | 2 | 3 | 4 | 6 | 8;
+  typeId?: 1 | 2 | 3 | 4 | 6 | 8 | -1;
 };
 export type ApiResponse = {
   code?: number;

--- a/demo/objectStyleArgument.ts
+++ b/demo/objectStyleArgument.ts
@@ -44,7 +44,7 @@ export type Pet = {
   /** Size scale for pets */
   size?: "P" | "M" | "G" | "0";
   /** integer test case for #349 */
-  typeId?: 1 | 2 | 3 | 4 | 6 | 8;
+  typeId?: 1 | 2 | 3 | 4 | 6 | 8 | -1;
 };
 export type ApiResponse = {
   code?: number;

--- a/demo/optimisticApi.ts
+++ b/demo/optimisticApi.ts
@@ -44,7 +44,7 @@ export type Pet = {
   /** Size scale for pets */
   size?: "P" | "M" | "G" | "0";
   /** integer test case for #349 */
-  typeId?: 1 | 2 | 3 | 4 | 6 | 8;
+  typeId?: 1 | 2 | 3 | 4 | 6 | 8 | -1;
 };
 export type ApiResponse = {
   code?: number;

--- a/demo/petstore.json
+++ b/demo/petstore.json
@@ -1523,7 +1523,7 @@
           },
           "typeId": {
             "description": "integer test case for #349",
-            "enum": [1, 2, 3, 4, 6, 8],
+            "enum": [1, 2, 3, 4, 6, 8, -1],
             "type": "integer",
             "x-enumNames": [
               "dog",
@@ -1531,7 +1531,8 @@
               "tiger",
               "mouse",
               "house",
-              "3-headed-monkey"
+              "3-headed-monkey",
+              "unicorn"
             ]
           }
         },

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -858,12 +858,12 @@ export default class ApiGenerator {
         const name = names ? names[index] : String(s);
         return factory.createEnumMember(
           factory.createIdentifier(toIdentifier(name, true)),
-          factory.createNumericLiteral(s),
+          cg.createLiteral(s),
         );
       }
       return factory.createEnumMember(
         factory.createIdentifier(toIdentifier(s, true)),
-        factory.createStringLiteral(s),
+        cg.createLiteral(s),
       );
     });
     this.enumAliases.push(


### PR DESCRIPTION
very similar to #626 , but this time while creating numeric enums:

```
> generate-api
> oazapfts ../src/backend/web/static/swagger/api_v3.json --argumentStyle=object --useEnumType > app/api/v3.ts

/home/justin/code/frc/the-blue-alliance/pwa/node_modules/typescript/lib/typescript.js:25239
    Debug.assert(text.charCodeAt(0) !== 45 /* minus */, "Negative numbers should be created in combination with createPrefixUnaryExpression");
          ^

Error: Debug Failure. False expression: Negative numbers should be created in combination with createPrefixUnaryExpression
    at Object.createNumericLiteral (/home/justin/code/frc/the-blue-alliance/pwa/node_modules/typescript/lib/typescript.js:25239:11)
    at file:///home/justin/code/frc/the-blue-alliance/pwa/node_modules/oazapfts/tscodegen-wH2Xseqv.js:543:13
    at Array.map (<anonymous>)
    at st.getTrueEnum (file:///home/justin/code/frc/the-blue-alliance/pwa/node_modules/oazapfts/tscodegen-wH2Xseqv.js:538:17)
    at st.getBaseTypeFromSchema (file:///home/justin/code/frc/the-blue-alliance/pwa/node_modules/oazapfts/tscodegen-wH2Xseqv.js:486:47)
    at st.getTypeFromSchema (file:///home/justin/code/frc/the-blue-alliance/pwa/node_modules/oazapfts/tscodegen-wH2Xseqv.js:396:20)
    at st.getRefAlias (file:///home/justin/code/frc/the-blue-alliance/pwa/node_modules/oazapfts/tscodegen-wH2Xseqv.js:288:21)
    at st.getBaseTypeFromSchema (file:///home/justin/code/frc/the-blue-alliance/pwa/node_modules/oazapfts/tscodegen-wH2Xseqv.js:407:19)
    at st.getTypeFromSchema (file:///home/justin/code/frc/the-blue-alliance/pwa/node_modules/oazapfts/tscodegen-wH2Xseqv.js:396:20)
    at file:///home/justin/code/frc/the-blue-alliance/pwa/node_modules/oazapfts/tscodegen-wH2Xseqv.js:612:20
```

Please let me know if there are any additional steps to run, not very familiar with the repo.