### PR TITLE
fix: pass required properties to children in `allOf` schemas

### DIFF
--- a/packages/codegen/src/generate.test.ts
+++ b/packages/codegen/src/generate.test.ts
@@ -42,6 +42,39 @@ describe("content types", () => {
   });
 });
 
+describe("getBaseTypeFromSchema", () => {
+  it("should generate type with required properties when extending a schema with the 'allOf' operator", () => {
+    const generator = new ApiGenerator({} as unknown as OpenAPIV3.Document);
+    const node = generator.getBaseTypeFromSchema(
+      {
+        type: "object",
+        allOf: [
+          {
+            type: "object",
+            properties: {
+              firstName: {
+                type: "string",
+              },
+              secondName: {
+                type: "string",
+              },
+            },
+          },
+        ],
+        required: ["firstName"],
+      },
+      "Person"
+    );
+
+    expect(printNode(node)).toMatchInlineSnapshot(`
+      "{
+          firstName: string;
+          secondName?: string;
+      }"
+    `);
+  });
+});
+
 describe("union types defined by type: array", () => {
   it("should generate a union type", () => {
     const generator = new ApiGenerator({} as unknown as OpenAPIV3.Document);

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -715,7 +715,16 @@ export default class ApiGenerator {
             ),
           );
         } else {
-          types.push(this.getTypeFromSchema(childSchema, undefined, onlyMode));
+          types.push(
+            this.getTypeFromSchema(
+              {
+                required: schema.required,
+                ...childSchema,
+              },
+              undefined,
+              onlyMode
+            )
+          );
         }
       }
 


### PR DESCRIPTION
According to the OpenAPI spec, annotating an `allOf` schema with a `required` property is valid. I don't believe this package was fully supporting that use case, as we were observing that with the following spec:

```yml
    getPerson:
      type: object
      allOf:
        - type: object
          properties:
            firstName:
              type: string
            secondName:
              type: string
      required:
        - firstName
```

We were getting this result:

```
{
    firstName?: string;
    secondName?: string;
}
```

When it should in fact be:

```
{
    firstName: string;
    secondName?: string;
}
```

I think we can fix this by simply passing the required property on the parent through with the child schema, and has in fact been working for us (as an applied `patch-package`) for some time now. But also, if this is completely wrong, please do let me know.
