### PR TITLE
Fix issue with enum discriminators

### DIFF
--- a/packages/codegen/src/__fixtures__/allOf.json
+++ b/packages/codegen/src/__fixtures__/allOf.json
@@ -117,7 +117,9 @@
         "discriminator": {
           "propertyName": "petType",
           "mapping": {
-            "dog": "#/components/schemas/Dog"
+            "dog": "#/components/schemas/Dog",
+            "poodle": "#/components/schemas/Dog",
+            "cat": "#/components/schemas/Cat"
           }
         }
       },

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -687,7 +687,7 @@ export default class ApiGenerator {
     }
     if (schema.allOf) {
       // allOf -> intersection
-      const types = [];
+      const types: Array<ts.TypeNode> = [];
       for (const childSchema of schema.allOf) {
         if (
           isReference(childSchema) &&
@@ -696,7 +696,7 @@ export default class ApiGenerator {
           const discriminatingSchema =
             this.resolve<DiscriminatingSchemaObject>(childSchema);
           const discriminator = discriminatingSchema.discriminator;
-          const matched = Object.entries(discriminator.mapping || {}).find(
+          const matched = Object.entries(discriminator.mapping ?? {}).find(
             ([, ref]) => ref === schema["x-component-ref-path"],
           );
           if (matched) {

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -696,18 +696,15 @@ export default class ApiGenerator {
           const discriminatingSchema =
             this.resolve<DiscriminatingSchemaObject>(childSchema);
           const discriminator = discriminatingSchema.discriminator;
-          const matched = Object.entries(discriminator.mapping ?? {}).find(
-            ([, ref]) => ref === schema["x-component-ref-path"],
-          );
-          if (matched) {
-            const [discriminatorValue] = matched;
+          const matches = Object.entries(discriminator.mapping ?? {})
+            .filter(([, ref]) => ref === schema["x-component-ref-path"])
+            .map(([discriminatorValue]) => discriminatorValue);
+          if (matches.length > 0) {
             types.push(
               factory.createTypeLiteralNode([
                 cg.createPropertySignature({
                   name: discriminator.propertyName,
-                  type: factory.createLiteralTypeNode(
-                    factory.createStringLiteral(discriminatorValue),
-                  ),
+                  type: this.getTypeFromEnum(matches),
                 }),
               ]),
             );

--- a/packages/codegen/src/generate.ts
+++ b/packages/codegen/src/generate.ts
@@ -605,8 +605,10 @@ export default class ApiGenerator {
     } else {
       // oneOf -> untagged union
       return factory.createUnionTypeNode(
-        variants.map((schema) =>
-          this.getTypeFromSchema(schema, undefined, onlyMode),
+        _.uniq(
+          variants.map((schema) =>
+            this.getTypeFromSchema(schema, undefined, onlyMode),
+          ),
         ),
       );
     }

--- a/packages/codegen/src/index.test.ts
+++ b/packages/codegen/src/index.test.ts
@@ -11,7 +11,7 @@ const demoFolder = path.join(rootFolder, "demo");
 /**
  * Generate an API from a relative path and convert it into a single line.
  */
-async function generate(file: string, opts: Opts = {}): Promise<string> {
+async function generate(file: string, opts: Opts = {}) {
   const src = await generateSource(file, opts);
   const error = await checkForTypeErrors(src);
   expect(error).toBeUndefined();

--- a/packages/codegen/src/index.test.ts
+++ b/packages/codegen/src/index.test.ts
@@ -60,8 +60,12 @@ describe("generateSource", () => {
     expect(src).toContain(`export type Option = ("one" | "two" | "three")[];`);
   });
 
-  it(async () => {
-    const src = await generate(__dirname + "/__fixtures__/allOf.json");
+  describe("discriminator mappings with allOf", () => {
+    let src: string;
+
+    beforeAll(async () => {
+      src = await generate(__dirname + "/__fixtures__/allOf.json");
+    });
 
     it("should handle properties both inside and outside of allOf", async () => {
       expect(src).toContain(

--- a/packages/codegen/src/index.test.ts
+++ b/packages/codegen/src/index.test.ts
@@ -72,7 +72,10 @@ describe("generateSource", () => {
     expect(src).toContain("export type PetBase = { petType: string; };");
     expect(src).toContain("export type Pet = Dog | Cat | Lizard;");
     expect(src).toContain(
-      'export type Dog = { petType: "dog"; } & PetBase & { bark?: string; };',
+      'export type Cat = { petType: "cat"; } & PetBase & { name?: string; };',
+    );
+    expect(src).toContain(
+      'export type Dog = { petType: "dog" | "poodle"; } & PetBase & { bark?: string; };',
     );
     expect(src).toContain(
       'export type Lizard = { petType: "Lizard"; } & PetBase & { lovesRocks?: boolean; };',

--- a/packages/codegen/src/index.test.ts
+++ b/packages/codegen/src/index.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeAll, assert } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import * as path from "node:path";
-import { Opts, generateSource } from "./index";
+import { generateSource, Opts } from "./index";
 import { readFile } from "node:fs/promises";
 import { createProject, ts } from "@ts-morph/bootstrap";
 import { ScriptTarget } from "typescript";
@@ -11,7 +11,7 @@ const demoFolder = path.join(rootFolder, "demo");
 /**
  * Generate an API from a relative path and convert it into a single line.
  */
-async function generate(file: string, opts: Opts = {}) {
+async function generate(file: string, opts: Opts = {}): Promise<string> {
   const src = await generateSource(file, opts);
   const error = await checkForTypeErrors(src);
   expect(error).toBeUndefined();
@@ -60,26 +60,28 @@ describe("generateSource", () => {
     expect(src).toContain(`export type Option = ("one" | "two" | "three")[];`);
   });
 
-  it("should handle properties both inside and outside of allOf", async () => {
+  it(async () => {
     const src = await generate(__dirname + "/__fixtures__/allOf.json");
-    expect(src).toContain(
-      "export type Circle = Shape & { radius?: number; } & { circumference?: number; };",
-    );
-  });
 
-  it("should support discriminator used in conjunction with allOf", async () => {
-    const src = await generate(__dirname + "/__fixtures__/allOf.json");
-    expect(src).toContain("export type PetBase = { petType: string; };");
-    expect(src).toContain("export type Pet = Dog | Cat | Lizard;");
-    expect(src).toContain(
-      'export type Cat = { petType: "cat"; } & PetBase & { name?: string; };',
-    );
-    expect(src).toContain(
-      'export type Dog = { petType: "dog" | "poodle"; } & PetBase & { bark?: string; };',
-    );
-    expect(src).toContain(
-      'export type Lizard = { petType: "Lizard"; } & PetBase & { lovesRocks?: boolean; };',
-    );
+    it("should handle properties both inside and outside of allOf", async () => {
+      expect(src).toContain(
+        "export type Circle = Shape & { radius?: number; } & { circumference?: number; };",
+      );
+    });
+
+    it("should support discriminator used in conjunction with allOf", async () => {
+      expect(src).toContain("export type PetBase = { petType: string; };");
+      expect(src).toContain(
+        'export type Cat = { petType: "cat"; } & PetBase & { name?: string; };',
+      );
+      expect(src).toContain(
+        'export type Dog = { petType: "dog" | "poodle"; } & PetBase & { bark?: string; };',
+      );
+      expect(src).toContain(
+        'export type Lizard = { petType: "Lizard"; } & PetBase & { lovesRocks?: boolean; };',
+      );
+      expect(src).toContain("export type Pet = Dog | Cat | Lizard;");
+    });
   });
 
   it("should support recursive schemas", async () => {

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -31,7 +31,10 @@ export function printAst(ast: ts.SourceFile) {
   return cg.printFile(ast);
 }
 
-export async function generateSource(spec: string, opts: Opts = {}) {
+export async function generateSource(
+  spec: string,
+  opts: Opts = {},
+): Promise<string> {
   const { doc, isConverted } = await parseSpec(spec);
   const ast = generateAst(doc, opts, isConverted);
   const { title, version } = doc.info;

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -32,7 +32,7 @@ export function printAst(ast: ts.SourceFile) {
 }
 
 export async function generateSource(spec: string, opts: Opts = {}) {
-  var { doc, isConverted } = await parseSpec(spec);
+  const { doc, isConverted } = await parseSpec(spec);
   const ast = generateAst(doc, opts, isConverted);
   const { title, version } = doc.info;
   const preamble = ["$&", title, version].filter(Boolean).join("\n * ");


### PR DESCRIPTION
When generating code from a schema like this
```
"Pet": {
  "type": "object",
  "properties": {
    "petType": {
      "type": "string"
    }
  },
  "required": ["petType"],
  "discriminator": {
    "propertyName": "petType",
    "mapping": {
      "dog": "#/components/schemas/Dog",
      "poodle": "#/components/schemas/Dog",
      "cat": "#/components/schemas/Cat"
    }
  }
}
```
I would expect to see the following TypeScript output
```ts
export type PetBase = { petType: string };
export type Dog = { petType: "dog" | "poodle" } & PetBase & { bark?: string };
export type Cat = { petType: "cat" } & PetBase & { name?: string };
export type Pet = Dog | Cat;
```
However, `oazapfts` generates the following instead
```ts
export type PetBase = { petType: string };
export type Dog = { petType: "dog" } & PetBase & { bark?: string };
export type Cat = { petType: "Cat" } & PetBase & { name?: string };
export type Lizard = { petType: "Lizard" } & PetBase & { lovesRocks?: boolean };
export type Pet = Dog | Cat | Lizard;
```
There is a problem with this - `Dog` can't be picked by the value `'poodle'`. It picks the "first" mapping entry instead of using all mapping entries. This has caused issues in my workflow, as the generated code for our web app ends up having incomplete type information. This issue has been logged in https://github.com/oazapfts/oazapfts/issues/674 and https://github.com/oazapfts/oazapfts/issues/611

In my case, my schema has 3 mapping entries pointing to the same schema. I'm sure you can see how this would cause issues.

Anyway, this PR aims to resolve that.