### PR TITLE
feat: all schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Options:
 --useUnknown
 --mergeReadWriteOnly
 --argumentStyle=<positional | object> (default: positional)
+--allSchemas
 ```
 
 Where `<spec>` is the URL or local path of an OpenAPI or Swagger spec (in either json or yml) and `<filename>` is the location of the `.ts` file to be generated. If the filename is omitted, the code is written to stdout.
@@ -54,6 +55,8 @@ Where `<spec>` is the URL or local path of an OpenAPI or Swagger spec (in either
 - `--mergeReadWriteOnly` by default oazapfs will generate separate types for read-only and write-only properties. This option will merge them into one type.
 
 - `--argumentStyle` if "object" generated functions take single object style argument for parameters and requestBody, by default it's "positional" and parameters are separate as positional arguments
+
+- `--allSchemas` generate types for all schemas included in the spec
 
 ## Consuming the generated API
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "npm run test:unit -- --run && npm run test:e2e",
     "validate": "npm run lint && npm test && npm run test:e2e:clean && npm run type-check",
     "lint": "prettier --check .",
+    "lint:fix": "prettier --write .",
     "type-check": "cd packages/codegen && tsc --noEmit && cd ../runtime && tsc --noEmit",
     "test:unit": "cd packages && vitest",
     "test:e2e": "npm run generate-demo && with-server 'cd demo && vitest --run'",

--- a/packages/codegen/src/__fixtures__/extraSchema.json
+++ b/packages/codegen/src/__fixtures__/extraSchema.json
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Extra schema example",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {},
+  "components": {
+    "schemas": {
+      "BlogEntry": {
+        "type": "object",
+        "required": ["id", "title", "content"],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": true
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/packages/codegen/src/cli.ts
+++ b/packages/codegen/src/cli.ts
@@ -16,6 +16,7 @@ async function run(argv: ParsedArgs) {
     mergeReadWriteOnly,
     useUnknown,
     argumentStyle,
+    allSchemas,
     help,
     version,
   } = argv;
@@ -59,6 +60,7 @@ async function run(argv: ParsedArgs) {
     useUnknown,
     mergeReadWriteOnly,
     argumentStyle,
+    allSchemas,
   });
 
   if (dest) await writeFile(dest, code);
@@ -80,6 +82,7 @@ function printUsage() {
     --useUnknown
     --mergeReadWriteOnly
     --argumentStyle=<${argumentStyleOptions.join(" | ")}> (default: positional)
+    --allSchemas
 `);
 }
 
@@ -98,6 +101,7 @@ run(
       "useEnumType",
       "mergeReadWriteOnly",
       "useUnknown",
+      "allSchemas",
     ],
     string: ["argumentStyle"],
   }),

--- a/packages/codegen/src/generate/generateApi.ts
+++ b/packages/codegen/src/generate/generateApi.ts
@@ -7,6 +7,7 @@ import { createDefaultsStatement } from "./createDefaultsStatement";
 import * as OpenAPI from "../helpers/openApi3-x";
 import type { UNSTABLE_OazapftsPluginHooks } from "../plugin";
 import { createServersStatement } from "./generateServers";
+import { getRefAlias } from "./getRefAlias";
 
 export async function generateApi(
   ctx: OazapftsContext,
@@ -50,6 +51,12 @@ export async function generateApi(
       );
 
       methods.push(...generatedMethods);
+    }
+  }
+
+  if (ctx.opts.allSchemas && ctx.spec.components?.schemas) {
+    for (const [name, schema] of Object.entries(ctx.spec.components.schemas)) {
+      getRefAlias({ $ref: `#/components/schemas/${name}` }, ctx, schema);
     }
   }
 

--- a/packages/codegen/src/index.test.ts
+++ b/packages/codegen/src/index.test.ts
@@ -108,6 +108,7 @@ describe("index exports (public API surface)", () => {
       useUnknown: true,
       optimistic: true,
       unionUndefined: true,
+      allSchemas: false,
       UNSTABLE_plugins: [],
     };
   });
@@ -659,5 +660,21 @@ describe("argumentStyle", () => {
         `function getInventory(opts?: Oazapfts.RequestOpts) { return oazapfts.fetchJson<{ status: 200; data: { [key: string]: number; }; }>("/store/inventory", { ...opts }); }`,
       );
     });
+  });
+});
+
+describe("allSchemas", () => {
+  it("should not include all schemas by default", async () => {
+    const src = await generate(__dirname + "/__fixtures__/extraSchema.json");
+    expect(src).not.toContain(`export type BlogEntry`);
+  });
+
+  it("should include all schemas", async () => {
+    const src = await generate(__dirname + "/__fixtures__/extraSchema.json", {
+      allSchemas: true,
+    });
+    expect(src).toContain(
+      `export type BlogEntry = { id: number; title: string; content: any | null; };`,
+    );
   });
 });

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -22,6 +22,7 @@ export type OazapftsOptions = {
   mergeReadWriteOnly?: boolean;
   useUnknown?: boolean;
   argumentStyle?: ArgumentStyle;
+  allSchemas?: boolean;
   /**
    * Plugins to apply during code generation.
    * Each plugin receives hooks and can tap into generation steps.


### PR DESCRIPTION
Add an extra option `allSchemas`, in order to configure oazapfts to include all schemas in `components.schemas`, not just the schemas it found while generating the rest of the client.

Fixes #325