### PR TITLE
test: cover optional security generation

### DIFF
--- a/packages/codegen/src/index.test.ts
+++ b/packages/codegen/src/index.test.ts
@@ -195,6 +195,39 @@ describe("generateSource", () => {
     expect(src).not.toContain("internalOp");
   });
 
+  it("should generate operations with anonymous security alternatives", async () => {
+    const src = await generateSource({
+      openapi: "3.0.0",
+      info: { title: "Security API", version: "1.0.0" },
+      paths: {
+        "/items": {
+          get: {
+            operationId: "listItems",
+            security: [{}, { apiKeyAuth: [] }],
+            responses: {
+              "204": {
+                description: "No content",
+              },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          apiKeyAuth: {
+            type: "apiKey",
+            in: "header",
+            name: "X-API-Key",
+          },
+        },
+      },
+    } as OpenAPI.Document);
+    const error = await checkForTypeErrors(src);
+
+    expect(error).toBeUndefined();
+    expect(src).toContain("function listItems(opts?: Oazapfts.RequestOpts)");
+  });
+
   it("should handle enums as union types", async () => {
     const src = await generate(path.join(demoFolder, "./petstore.json"));
     expect(src).toContain(`export type Option = ("one" | "two" | "three")[];`);


### PR DESCRIPTION
Summary
- Adds generator coverage for OpenAPI operations with an anonymous `{}` security alternative and an API-key option.
- Verifies the generated client remains type-checkable and exposes the expected operation method.

Validation
- `npm ci --ignore-scripts`
- `npm run build -w @oazapfts/resolve`
- `npm run build -w @oazapfts/runtime`
- `cd packages && vitest --run codegen/src/index.test.ts -t "anonymous security"`
- `git diff --check`

Duplicate gate
- Checked memory, target tree, direct PR and issue lists, and earlier clean search results before the GitHub Search endpoint rate-limited later checks. No same-surface duplicate found.